### PR TITLE
Opravit přejmenování záložek podlaží (dblclick)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3107,10 +3107,11 @@ function renderLevelTabs() {
         removeLevel(parseInt(e.target.dataset.idx));
         return;
       }
-      switchLevel(idx);
+      if (idx !== appState.activeLevel) switchLevel(idx);
     });
     tab.addEventListener('dblclick', (e) => {
       if (e.target.classList.contains('tab-close')) return;
+      e.stopPropagation();
       startRenameTab(tab, idx);
     });
     container.appendChild(tab);


### PR DESCRIPTION
Kliknutí na aktivní záložku volalo switchLevel() → renderLevelTabs() → DOM se přestavěl → dblclick dopadl na odpojený element → input se nikdy nezobrazil. Oprava: switchLevel jen pokud idx != activeLevel.

https://claude.ai/code/session_012HVqboJ7mXP1ZqCRQNPMxc