### PR TITLE
Opravit crop: mousedown na tlačítkách neresetuje výběr

### DIFF
--- a/index.html
+++ b/index.html
@@ -3514,6 +3514,7 @@ function setupCropOverlay() {
   const overlay = document.getElementById('crop-overlay');
   overlay.addEventListener('mousedown', e => {
     if (!cropState) return;
+    if (e.target.closest('#crop-actions')) return; // tlačítka neresetují výběr
     e.preventDefault();
     const r = overlay.getBoundingClientRect();
     cropState.startX = cropState.endX = e.clientX - r.left;


### PR DESCRIPTION
Klik na "Oříznout" bublal jako mousedown na overlay a přepsal startX/endX na pozici tlačítka → selW ≈ 0 → "Vyberte oblast". Fix: ignorovat mousedown pokud pochází z #crop-actions.

https://claude.ai/code/session_012HVqboJ7mXP1ZqCRQNPMxc