### PR TITLE
Ukládání anotací a subdodavatelů na server (plan_canvas_data)

### DIFF
--- a/api/canvas.php
+++ b/api/canvas.php
@@ -1,0 +1,94 @@
+<?php
+ob_start();
+ini_set('display_errors', 0);
+error_reporting(E_ALL);
+register_shutdown_function(function() {
+    $err = error_get_last();
+    if ($err && in_array($err['type'], [E_ERROR, E_CORE_ERROR, E_COMPILE_ERROR, E_PARSE, E_USER_ERROR])) {
+        ob_clean();
+        header('Content-Type: application/json');
+        http_response_code(500);
+        echo json_encode(['ok'=>false,'error'=>$err['message'],'file'=>basename($err['file']),'line'=>$err['line']]);
+    }
+});
+set_exception_handler(function($e) {
+    ob_clean();
+    header('Content-Type: application/json');
+    http_response_code(500);
+    echo json_encode(['ok'=>false,'error'=>$e->getMessage(),'file'=>basename($e->getFile()),'line'=>$e->getLine()]);
+    exit;
+});
+
+require_once __DIR__ . '/functions.php';
+
+$user      = requireAuth();
+$userId    = (int)$user['id'];
+$projectId = (int)($_GET['project_id'] ?? 0);
+$method    = $_SERVER['REQUEST_METHOD'];
+
+if (!$projectId) jsonError('Chybí project_id');
+
+// Ověř přístup k projektu
+$membership = getProjectMembership($projectId, $userId);
+if (!$membership) jsonError('Nemáš přístup k tomuto projektu', 403);
+
+// ============================================================
+// GET – načti canvas data projektu
+// ============================================================
+if ($method === 'GET') {
+    $stmt = getDB()->prepare(
+        'SELECT state_json, profese_json, annot_counter FROM plan_canvas_data WHERE project_id = ? LIMIT 1'
+    );
+    $stmt->execute([$projectId]);
+    $row = $stmt->fetch();
+
+    if (!$row || !$row['state_json']) {
+        jsonOk(['state' => null, 'profese' => null, 'counter' => 1]);
+    }
+
+    jsonOk([
+        'state'   => json_decode($row['state_json'],  true),
+        'profese' => $row['profese_json'] ? json_decode($row['profese_json'], true) : null,
+        'counter' => (int)($row['annot_counter'] ?? 1),
+    ]);
+}
+
+// ============================================================
+// POST – ulož canvas data projektu
+// Body: { state: {...levels...}, profese: [...], counter: N }
+// ============================================================
+if ($method === 'POST') {
+    $body    = json_decode(file_get_contents('php://input'), true) ?? [];
+    $state   = $body['state']   ?? null;
+    $profese = $body['profese'] ?? null;
+    $counter = (int)($body['counter'] ?? 1);
+
+    if ($state === null) jsonError('Chybí state');
+
+    // Odfiltruj backgroundImage z levels před uložením (příliš velká data)
+    if (isset($state['levels']) && is_array($state['levels'])) {
+        foreach ($state['levels'] as &$lvl) {
+            unset($lvl['backgroundImage'], $lvl['backgroundImageOriginal']);
+        }
+        unset($lvl);
+    }
+
+    getDB()->prepare('
+        INSERT INTO plan_canvas_data (project_id, state_json, profese_json, annot_counter)
+        VALUES (?, ?, ?, ?)
+        ON DUPLICATE KEY UPDATE
+            state_json    = VALUES(state_json),
+            profese_json  = VALUES(profese_json),
+            annot_counter = VALUES(annot_counter),
+            updated_at    = NOW()
+    ')->execute([
+        $projectId,
+        json_encode($state,   JSON_UNESCAPED_UNICODE),
+        $profese !== null ? json_encode($profese, JSON_UNESCAPED_UNICODE) : null,
+        $counter,
+    ]);
+
+    jsonOk();
+}
+
+jsonError('Metoda není povolena', 405);

--- a/index.html
+++ b/index.html
@@ -6637,31 +6637,67 @@ async function bgDBLoadAll(pid, levels) {
 let saveTimer = null;
 function saveState() {
   clearTimeout(saveTimer);
-  // Okamžité uložení – žádný debounce
-  _flushSave();
+  _flushSave();    // localStorage okamžitě
+  _serverSave();   // server s 2s debounce
 }
+
+function _buildStateObj() {
+  return {
+    levels: appState.levels.map(l => ({
+      id: l.id, name: l.name, type: l.type,
+      annotations: l.annotations,
+      fabricJSON: l.fabricJSON,
+      viewportTransform: l.viewportTransform,
+      hasBackground: !!l.backgroundImage,
+      color3D: l.color3D, shape3D: l.shape3D
+    })),
+    activeLevel: appState.activeLevel,
+    tool: appState.tool,
+    showGrid: appState.showGrid,
+    zones3D: appState.zones3D
+  };
+}
+
 function _flushSave() {
   if (!currentProject) return;
   try {
-    const stateToSave = {
-      levels: appState.levels.map(l => ({
-        id: l.id, name: l.name, type: l.type,
-        annotations: l.annotations,
-        fabricJSON: l.fabricJSON,
-        viewportTransform: l.viewportTransform,
-        hasBackground: !!l.backgroundImage,
-        color3D: l.color3D, shape3D: l.shape3D
-      })),
-      activeLevel: appState.activeLevel,
-      tool: appState.tool,
-      showGrid: appState.showGrid,
-      zones3D: appState.zones3D
-    };
     const pid = String(currentProject.id);
-    localStorage.setItem(LS_PROJECT_STATE(pid), JSON.stringify(stateToSave));
+    localStorage.setItem(LS_PROJECT_STATE(pid), JSON.stringify(_buildStateObj()));
     localStorage.setItem(LS_PROJECT_COUNTER(pid), String(annotIdCounter));
     localStorage.setItem(LS_PROJECT_PROFESE(pid), JSON.stringify(appState.profese));
   } catch(e) { /* localStorage plný */ }
+}
+
+// ---- Server save (debounce 2 s) ----
+let _srvTimer = null;
+function _serverSave() {
+  clearTimeout(_srvTimer);
+  _srvTimer = setTimeout(_serverSaveNow, 2000);
+}
+async function _serverSaveNow() {
+  if (!currentProject) return;
+  try {
+    await apiFetch(`api/canvas.php?project_id=${currentProject.id}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        state:   _buildStateObj(),
+        profese: appState.profese,
+        counter: annotIdCounter
+      })
+    });
+  } catch(e) { /* síťová chyba – data jsou v localStorage */ }
+}
+
+// ---- Server load ----
+async function _serverLoad(projectId) {
+  try {
+    const { ok, data } = await apiFetch(`api/canvas.php?project_id=${projectId}`);
+    if (ok && data.state && Array.isArray(data.state.levels) && data.state.levels.length > 0) {
+      return data;
+    }
+  } catch(e) {}
+  return null;
 }
 
 function loadState() {
@@ -7327,10 +7363,12 @@ async function doRegister() {
 
 // --- Logout ---
 async function doLogout() {
-  // Uložit stav před odhlášením (debounce by jinak uložil prázdná data)
+  // Uložit stav před odhlášením
   if (currentProject && fabricCanvas) {
     saveCurrentLevel();
     _flushSave();
+    clearTimeout(_srvTimer);
+    await _serverSaveNow(); // synchronní flush na server
   }
   clearTimeout(saveTimer);
   await apiFetch('api/auth.php?action=logout', { method: 'POST' });
@@ -7424,11 +7462,31 @@ async function openProject(proj) {
   appState.profese = JSON.parse(JSON.stringify(DEFAULT_PROFESE));
   annotIdCounter = 1;
   undoStack = []; redoStack = [];
-  loadState();
+
+  // Načti data ze serveru (primární) nebo z localStorage (záloha)
+  const serverData = await _serverLoad(proj.id);
+  if (serverData) {
+    const s = serverData.state;
+    appState.levels       = s.levels       || [];
+    appState.activeLevel  = s.activeLevel  || 0;
+    appState.tool         = s.tool         || 'select';
+    appState.showGrid     = s.showGrid     || false;
+    appState.zones3D      = s.zones3D      || [];
+    annotIdCounter        = serverData.counter || 1;
+    if (serverData.profese && Array.isArray(serverData.profese) && serverData.profese.length > 0) {
+      appState.profese = serverData.profese;
+    }
+    rebuildProfeseSelects();
+    if (s.showGrid) { document.getElementById('grid-btn').classList.add('active'); drawGrid(); }
+    setTool(appState.tool);
+  } else {
+    loadState(); // fallback na localStorage
+  }
+
   if (appState.levels.length === 0) {
     addLevel('1.NP', '1.NP');
   } else {
-    // Restore background images from IndexedDB before rendering
+    // Obnov obrázky pozadí z IndexedDB
     const pid = String(proj.id);
     await bgDBLoadAll(pid, appState.levels);
     renderLevelTabs();

--- a/setup.sql
+++ b/setup.sql
@@ -10,3 +10,15 @@ WHERE NOT EXISTS (SELECT 1 FROM apps WHERE app_key = 'plans');
 
 -- Ověření – měl bys vidět řádek plans | BeSix Plans
 SELECT * FROM apps WHERE app_key = 'plans';
+
+-- ============================================================
+-- Canvas data – ukládání stavu plátna (anotace, vrstvy, profese)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS plan_canvas_data (
+  project_id    INT          NOT NULL,
+  state_json    LONGTEXT,
+  profese_json  MEDIUMTEXT,
+  annot_counter INT          NOT NULL DEFAULT 1,
+  updated_at    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (project_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
Nová tabulka:
- plan_canvas_data(project_id PK, state_json LONGTEXT, profese_json MEDIUMTEXT, annot_counter INT, updated_at)

Nový endpoint api/canvas.php:
- GET ?project_id=X → vrátí state/profese/counter pro projekt
- POST ?project_id=X → uloží state/profese/counter (ON DUPLICATE KEY UPDATE)
- PHP odfiltruje backgroundImage před uložením (ta zůstává v IndexedDB)

JS změny v index.html:
- _buildStateObj(): extrahuje stav do společného objektu
- _serverSave(): debounce 2s → volá _serverSaveNow()
- _serverSaveNow(): POST na api/canvas.php
- _serverLoad(): GET z api/canvas.php, vrátí null při chybě
- saveState(): volá _flushSave() (localStorage) + _serverSave() (server)
- openProject(): načte data ze serveru (primárně), fallback na localStorage
- doLogout(): čeká na _serverSaveNow() před vymazáním stavu

https://claude.ai/code/session_012HVqboJ7mXP1ZqCRQNPMxc