### PR TITLE
Add service worker for offline caching

### DIFF
--- a/index.html
+++ b/index.html
@@ -8137,6 +8137,33 @@ document.addEventListener('visibilitychange', () => { if (document.visibilitySta
 window.addEventListener('pagehide', _beaconSave);
 
 // ============================================================
+// SERVICE WORKER
+// ============================================================
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('./sw.js').catch(() => {});
+}
+
+// Offline / online indikátor
+(function initOfflineIndicator() {
+  const bar = document.createElement('div');
+  bar.id = 'offline-bar';
+  bar.textContent = '⚠ Jste offline – výkresy jsou načteny z mezipaměti, uložení není dostupné';
+  bar.style.cssText = [
+    'display:none','position:fixed','bottom:0','left:0','right:0','z-index:9999',
+    'background:#7f1d1d','color:#fecaca','font-size:12px','font-family:monospace',
+    'padding:6px 16px','text-align:center','border-top:1px solid #991b1b'
+  ].join(';');
+  document.body.appendChild(bar);
+
+  function update() {
+    bar.style.display = navigator.onLine ? 'none' : 'block';
+  }
+  window.addEventListener('online',  update);
+  window.addEventListener('offline', update);
+  update();
+})();
+
+// ============================================================
 // MOBILE RIGHT PANEL TOGGLE
 // ============================================================
 (function initMobRightPanel() {

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,106 @@
+// BeSix Plans – Service Worker
+// Strategie: cache-first pro statické assety, network-first pro API
+const CACHE = 'besix-plans-v1';
+
+const PRECACHE = [
+  './',
+  './index.html',
+  './besix_logo_bila.png',
+  // CDN knihovny – fabric, three.js, pdf.js, jspdf
+  'https://cdnjs.cloudflare.com/ajax/libs/fabric.js/5.3.1/fabric.min.js',
+  'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js',
+  'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js',
+  'https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js',
+  'https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/loaders/GLTFLoader.js',
+  'https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/loaders/OBJLoader.js',
+  'https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js',
+  // Google Fonts CSS (font soubory se cachují automaticky při prvním načtení)
+  'https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Barlow+Condensed:wght@300;400;500;600;700&display=swap',
+];
+
+// ── Install: předcachovat klíčové zdroje ──────────────────────
+self.addEventListener('install', (e) => {
+  e.waitUntil(
+    caches.open(CACHE).then(cache =>
+      Promise.allSettled(PRECACHE.map(url =>
+        cache.add(url).catch(() => { /* CDN může selhat offline – nevadí */ })
+      ))
+    ).then(() => self.skipWaiting())
+  );
+});
+
+// ── Activate: smazat staré cache verze ────────────────────────
+self.addEventListener('activate', (e) => {
+  e.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k)))
+    ).then(() => self.clients.claim())
+  );
+});
+
+// ── Fetch: obsluha požadavků ───────────────────────────────────
+self.addEventListener('fetch', (e) => {
+  const url = new URL(e.request.url);
+
+  // API volání → network-first, offline = chybová odpověď
+  if (url.pathname.startsWith('/api/') || url.pathname.includes('api/')) {
+    e.respondWith(
+      fetch(e.request).catch(() =>
+        new Response(
+          JSON.stringify({ error: 'Jste offline. Akce bude dostupná po obnovení připojení.' }),
+          { status: 503, headers: { 'Content-Type': 'application/json' } }
+        )
+      )
+    );
+    return;
+  }
+
+  // uploads/ obrázky → cache-first (výkresy uložené na serveru)
+  if (url.pathname.startsWith('/uploads/') || url.pathname.includes('/uploads/')) {
+    e.respondWith(
+      caches.open(CACHE).then(cache =>
+        cache.match(e.request).then(cached => {
+          if (cached) return cached;
+          return fetch(e.request).then(resp => {
+            if (resp.ok) cache.put(e.request, resp.clone());
+            return resp;
+          }).catch(() => new Response('', { status: 503 }));
+        })
+      )
+    );
+    return;
+  }
+
+  // CDN zdroje a fonty → cache-first
+  if (url.origin !== location.origin) {
+    e.respondWith(
+      caches.match(e.request).then(cached => {
+        if (cached) return cached;
+        return fetch(e.request).then(resp => {
+          if (resp.ok) {
+            caches.open(CACHE).then(c => c.put(e.request, resp.clone()));
+          }
+          return resp;
+        }).catch(() => new Response('', { status: 503 }));
+      })
+    );
+    return;
+  }
+
+  // index.html + lokální soubory → network-first, fallback na cache
+  e.respondWith(
+    fetch(e.request).then(resp => {
+      if (resp.ok) {
+        caches.open(CACHE).then(c => c.put(e.request, resp.clone()));
+      }
+      return resp;
+    }).catch(() =>
+      caches.match(e.request).then(cached =>
+        cached || new Response('Offline – načtěte stránku po obnovení připojení.', {
+          status: 503,
+          headers: { 'Content-Type': 'text/plain; charset=utf-8' }
+        })
+      )
+    )
+  );
+});


### PR DESCRIPTION
- sw.js: cache-first for CDN libs (fabric.js, three.js, pdf.js, jspdf, fonts) and /uploads/ floor plan images; network-first for index.html; API calls fail gracefully with JSON 503 when offline
- Register SW in index.html
- Red bar at bottom of screen when device loses connection, auto-hides when back online

https://claude.ai/code/session_012HVqboJ7mXP1ZqCRQNPMxc