### PR TITLE
Add hourly backup, live sync polling, and viewer-only mode

### DIFF
--- a/api/canvas.php
+++ b/api/canvas.php
@@ -69,28 +69,36 @@ function _decompress(string $val): string {
 // GET – načti canvas data projektu
 // ============================================================
 if ($method === 'GET') {
+    // Lightweight timestamp-only poll for live sync
+    if (!empty($_GET['ts_only'])) {
+        $stmt = getDB()->prepare('SELECT updated_at FROM plan_canvas_data WHERE project_id = ? LIMIT 1');
+        $stmt->execute([$projectId]);
+        $row = $stmt->fetch();
+        jsonOk(['updated_at' => $row['updated_at'] ?? null]);
+    }
+
     $stmt = getDB()->prepare(
-        'SELECT state_json, profese_json, annot_counter FROM plan_canvas_data WHERE project_id = ? LIMIT 1'
+        'SELECT state_json, profese_json, annot_counter, updated_at FROM plan_canvas_data WHERE project_id = ? LIMIT 1'
     );
     $stmt->execute([$projectId]);
     $row = $stmt->fetch();
 
     if (!$row || !$row['state_json']) {
-        jsonOk(['state' => null, 'profese' => null, 'counter' => 1]);
+        jsonOk(['state' => null, 'profese' => null, 'counter' => 1, 'updated_at' => null]);
     }
 
     $state   = json_decode(_decompress($row['state_json']), true);
     $profese = $row['profese_json'] ? json_decode(_decompress($row['profese_json']), true) : null;
 
     if ($state === null) {
-        // Dekomprese nebo parsování selhalo – vrať prázdný stav
-        jsonOk(['state' => null, 'profese' => null, 'counter' => 1]);
+        jsonOk(['state' => null, 'profese' => null, 'counter' => 1, 'updated_at' => null]);
     }
 
     jsonOk([
-        'state'   => $state,
-        'profese' => $profese,
-        'counter' => (int)($row['annot_counter'] ?? 1),
+        'state'      => $state,
+        'profese'    => $profese,
+        'counter'    => (int)($row['annot_counter'] ?? 1),
+        'updated_at' => $row['updated_at'] ?? null,
     ]);
 }
 

--- a/index.html
+++ b/index.html
@@ -3028,6 +3028,22 @@ th.sort-desc .sort-arrow::after { content: '▼'; opacity: 1; }
   <div class="status-item" id="status-tool-info">Nástroj: Výběr</div>
   <div class="status-sep">|</div>
   <div class="status-item" id="status-save-info" style="color:var(--text-dim)">💾 –</div>
+  <div class="status-sep">|</div>
+  <div class="status-item" id="status-sync-info" style="display:none;color:var(--olive-light);cursor:pointer;" title="Jiný uživatel upravil projekt – klikni pro načtení">🔄 Nová data</div>
+  <button id="backup-btn" title="Zálohy projektu" style="margin-left:8px;background:none;border:none;color:var(--text-dim);font-size:11px;cursor:pointer;padding:0 4px;" onclick="openBackupModal()">🗂 Zálohy</button>
+</div>
+
+<!-- BACKUP MODAL -->
+<div id="backup-modal" style="display:none;position:fixed;inset:0;z-index:9000;background:rgba(0,0,0,0.6);align-items:center;justify-content:center;">
+  <div style="background:var(--panel);border:1px solid var(--border);border-radius:8px;padding:24px;min-width:360px;max-width:480px;max-height:80vh;display:flex;flex-direction:column;gap:12px;">
+    <div style="display:flex;justify-content:space-between;align-items:center;">
+      <span style="font-weight:700;font-size:14px;color:var(--text-bright);">🗂 Zálohy projektu</span>
+      <button onclick="closeBackupModal()" style="background:none;border:none;color:var(--text-dim);font-size:18px;cursor:pointer;">×</button>
+    </div>
+    <p style="font-size:11px;color:var(--text-dim);">Zálohy se ukládají každou hodinu a při otevření projektu. Uchovává se posledních 8 záloh.</p>
+    <div id="backup-list" style="overflow-y:auto;display:flex;flex-direction:column;gap:6px;"></div>
+    <div style="font-size:10px;color:var(--text-dim);border-top:1px solid var(--border);padding-top:8px;">Zálohy jsou uloženy v tomto prohlížeči (localStorage).</div>
+  </div>
 </div>
 
 <!-- CONTEXT MENU -->
@@ -7392,6 +7408,7 @@ async function _serverSaveNow() {
       const t = new Date().toLocaleTimeString('cs-CZ', {hour:'2-digit', minute:'2-digit', second:'2-digit'});
       console.log('[canvas] saved', data?.saved, 'compressed bytes at', t);
       if (saveEl) { saveEl.textContent = '💾 ' + t; saveEl.style.color = 'var(--text-dim)'; }
+      _lastOwnSaveTs = Date.now();
     }
   } catch(e) { console.error('[canvas] save network error:', e); showToast('Chyba uložení: síťová chyba', 'error'); }
   finally { _saving = false; }
@@ -8223,6 +8240,7 @@ async function openProject(proj) {
   // Načti data ze serveru (primární) nebo z localStorage (záloha)
   const serverData = await _serverLoad(proj.id);
   if (serverData) {
+    _lastKnownTs = serverData.updated_at || null;
     const s = serverData.state;
     appState.levels       = s.levels       || [];
     appState.activeLevel  = s.activeLevel  || 0;
@@ -8258,6 +8276,8 @@ async function openProject(proj) {
     switchLevel(appState.activeLevel);
     // Safety fallback: clear loading flag after 8s even if async callbacks don't fire
     setTimeout(() => { _isProjectLoading = false; }, 8000);
+    // Initial backup after project fully loads
+    setTimeout(() => saveBackup('Při otevření projektu'), 3000);
   }
 }
 
@@ -8387,6 +8407,173 @@ if ('serviceWorker' in navigator) {
     if (window.innerWidth <= 768) open();
   });
 })();
+
+// ============================================================
+// HOURLY BACKUP (localStorage)
+// ============================================================
+const MAX_BACKUPS = 8;
+function _backupKey(pid) { return 'besix_backups_' + pid; }
+
+function saveBackup(label) {
+  if (!currentProject || !canEdit()) return;
+  saveCurrentLevel();
+  const pid = String(currentProject.id);
+  let list = [];
+  try { list = JSON.parse(localStorage.getItem(_backupKey(pid)) || '[]'); } catch {}
+  const snap = {
+    ts:      Date.now(),
+    label:   label || new Date().toLocaleString('cs-CZ'),
+    state:   _buildStateObj(),
+    counter: annotIdCounter,
+    profese: appState.profese
+  };
+  list.unshift(snap);
+  if (list.length > MAX_BACKUPS) list = list.slice(0, MAX_BACKUPS);
+  try {
+    localStorage.setItem(_backupKey(pid), JSON.stringify(list));
+  } catch(e) {
+    // localStorage full – try with less
+    try { localStorage.setItem(_backupKey(pid), JSON.stringify(list.slice(0, 2))); } catch {}
+  }
+  console.log('[backup] Záloha uložena:', snap.label);
+}
+
+function getBackups() {
+  if (!currentProject) return [];
+  try { return JSON.parse(localStorage.getItem(_backupKey(String(currentProject.id))) || '[]'); } catch { return []; }
+}
+
+function openBackupModal() {
+  const list = getBackups();
+  const el = document.getElementById('backup-list');
+  if (!list.length) {
+    el.innerHTML = '<p style="color:var(--text-dim);font-size:12px;">Zatím žádné zálohy.</p>';
+  } else {
+    el.innerHTML = list.map((b, i) => `
+      <div style="display:flex;justify-content:space-between;align-items:center;padding:8px 10px;background:var(--card);border-radius:5px;gap:8px;">
+        <span style="font-size:12px;color:var(--text);">📅 ${escHtml(b.label)}</span>
+        <button onclick="restoreBackup(${i})" style="font-size:11px;padding:3px 10px;background:var(--olive);color:#fff;border:none;border-radius:4px;cursor:pointer;">Obnovit</button>
+      </div>`).join('');
+  }
+  document.getElementById('backup-modal').style.display = 'flex';
+}
+
+function closeBackupModal() {
+  document.getElementById('backup-modal').style.display = 'none';
+}
+
+async function restoreBackup(idx) {
+  const list = getBackups();
+  const b = list[idx];
+  if (!b) return;
+  const ok = await showModal('Obnovit zálohu', `Obnovit zálohu z ${b.label}? Aktuální neuložené změny budou ztraceny.`);
+  if (!ok) return;
+  closeBackupModal();
+
+  // Apply backup state
+  appState.levels = b.state.levels || [];
+  appState.activeLevel = b.state.activeLevel || 0;
+  annotIdCounter = b.counter || 1;
+  if (b.profese) appState.profese = b.profese;
+
+  // Reload backgrounds from IndexedDB
+  const pid = String(currentProject.id);
+  await bgDBLoadAll(pid, appState.levels);
+  appState.levels.forEach(lvl => {
+    if (!lvl.backgroundImage && lvl.bgServerUrl) lvl.backgroundImage = lvl.bgServerUrl;
+  });
+
+  renderLevelTabs();
+  _isProjectLoading = true;
+  switchLevel(appState.activeLevel);
+  setTimeout(() => { _isProjectLoading = false; }, 8000);
+  saveState();
+  showToast('Záloha obnovena: ' + b.label, 'success');
+}
+
+// Schedule hourly backup
+setInterval(() => saveBackup(), 60 * 60 * 1000);
+
+// ============================================================
+// LIVE SYNC – poll server every 10s for changes by other users
+// ============================================================
+let _lastKnownTs   = null;   // server updated_at we last saw
+let _lastOwnSaveTs = 0;      // when WE last saved successfully
+let _syncPending   = false;  // new remote data waiting for user
+
+async function _pollLiveSync() {
+  if (!currentProject || _isProjectLoading || _saving) return;
+  try {
+    const { ok, data } = await apiFetch(
+      `api/canvas.php?project_id=${currentProject.id}&ts_only=1`
+    );
+    if (!ok || !data.updated_at) return;
+
+    const remoteTs = data.updated_at;
+    if (_lastKnownTs === null) { _lastKnownTs = remoteTs; return; } // init
+    if (remoteTs === _lastKnownTs) return;                          // no change
+
+    // Something changed on server
+    _lastKnownTs = remoteTs;
+
+    // If we saved ourselves <6s ago, this is likely our own save – ignore
+    if (Date.now() - _lastOwnSaveTs < 6000) return;
+
+    // Fetch full data and merge inactive levels silently
+    const serverData = await _serverLoad(currentProject.id);
+    if (!serverData) return;
+
+    const remoteLevels = serverData.state.levels || [];
+    let changed = false;
+
+    remoteLevels.forEach((remLvl, i) => {
+      if (i === appState.activeLevel) return; // never overwrite active level
+      if (!appState.levels[i]) return;
+      appState.levels[i].fabricJSON   = remLvl.fabricJSON;
+      appState.levels[i].annotations  = remLvl.annotations;
+      appState.levels[i].bgServerUrl  = remLvl.bgServerUrl || appState.levels[i].bgServerUrl;
+      appState.levels[i].bgLeft       = remLvl.bgLeft;
+      appState.levels[i].bgTop        = remLvl.bgTop;
+      appState.levels[i].bgScaleX     = remLvl.bgScaleX;
+      appState.levels[i].bgScaleY     = remLvl.bgScaleY;
+      changed = true;
+    });
+
+    if (serverData.counter > annotIdCounter) annotIdCounter = serverData.counter;
+
+    // Check if active level also changed (show notification instead of forcing reload)
+    const remActive = remoteLevels[appState.activeLevel];
+    const locActive = appState.levels[appState.activeLevel];
+    const remoteAnnotCount = (remActive?.annotations || []).length;
+    const localAnnotCount  = (locActive?.annotations  || []).length;
+    if (remActive && remoteAnnotCount !== localAnnotCount) {
+      _syncPending = true;
+      const si = document.getElementById('status-sync-info');
+      if (si) si.style.display = '';
+    }
+
+    if (changed) updateAnnotList();
+
+  } catch(e) { /* network error – skip silently */ }
+}
+
+// Wire the "Nová data" badge click to reload active level
+document.getElementById('status-sync-info').addEventListener('click', async () => {
+  document.getElementById('status-sync-info').style.display = 'none';
+  _syncPending = false;
+  const serverData = await _serverLoad(currentProject.id);
+  if (!serverData) return;
+  const remLvl = (serverData.state.levels || [])[appState.activeLevel];
+  if (!remLvl) return;
+  appState.levels[appState.activeLevel].fabricJSON  = remLvl.fabricJSON;
+  appState.levels[appState.activeLevel].annotations = remLvl.annotations;
+  _isProjectLoading = true;
+  switchLevel(appState.activeLevel);
+  setTimeout(() => { _isProjectLoading = false; }, 8000);
+  showToast('Aktivní podlaží obnoveno ze serveru', 'success');
+});
+
+setInterval(_pollLiveSync, 10000);
 </script>
 
 <button id="mob-props-open-btn" title="Vlastnosti anotace">


### PR DESCRIPTION
- Hourly localStorage backup (max 8 snapshots) with restore UI via backup modal
- Live sync: poll canvas.php?ts_only=1 every 10s, merge inactive levels silently, show 'Nová data' badge when active level is changed by another user
- canvas.php: lightweight ts_only endpoint + updated_at in full GET response
- Track _lastOwnSaveTs after each successful save to skip our own save echoes
- Initialize _lastKnownTs from server updated_at on project open
- Save initial backup 3s after project loads (after fabric canvas is ready)
- Viewer role (non-owner/admin/member) cannot save; applyViewerMode() hides tools

https://claude.ai/code/session_012HVqboJ7mXP1ZqCRQNPMxc