### PR TITLE
Fix missing const LEVEL_TYPES declaration (syntax error broke login)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3278,6 +3278,8 @@ function recolorAnnotationsByProfese(profeseName) {
     saveCurrentLevel();
   }
 }
+
+const LEVEL_TYPES = {
   '1.NP': { icon: '→', color: '#3B82F6', cssClass: 'tab-type-np1' },
   '2.NP': { icon: '↑', color: '#10B981', cssClass: 'tab-type-np2' },
   '3.NP': { icon: '↑', color: '#10B981', cssClass: 'tab-type-np2' },


### PR DESCRIPTION
Previous edit that added recolorAnnotationsByProfese accidentally consumed the 'const LEVEL_TYPES = {' line in its old_string without restoring it, leaving the object properties as a bare label expression → syntax error that prevented any JS from running.