### PR TITLE
Fix HTTP 500 after Google OAuth login

### DIFF
--- a/api/functions.php
+++ b/api/functions.php
@@ -52,29 +52,35 @@ function _ensureRememberTable(): void {
     $done = true;
 }
 
-/** Issue a new remember-me cookie and store its hash in DB. */
+/** Issue a new remember-me cookie and store its hash in DB.
+ *  Silently skips if DB table is missing or user has no CREATE rights. */
 function setRememberCookie(int $userId): void {
-    _ensureRememberTable();
-    $db    = getDB();
-    $token = bin2hex(random_bytes(32));   // 64 hex chars
-    $hash  = hash('sha256', $token);
-    $exp   = date('Y-m-d H:i:s', time() + 86400 * REMEMBER_DAYS);
+    try {
+        _ensureRememberTable();
+        $db    = getDB();
+        $token = bin2hex(random_bytes(32));   // 64 hex chars
+        $hash  = hash('sha256', $token);
+        $exp   = date('Y-m-d H:i:s', time() + 86400 * REMEMBER_DAYS);
 
-    // Remove all existing tokens for this user + any expired tokens
-    $db->prepare("DELETE FROM remember_tokens WHERE user_id = ? OR expires_at < NOW()")
-       ->execute([$userId]);
+        // Remove all existing tokens for this user + any expired tokens
+        $db->prepare("DELETE FROM remember_tokens WHERE user_id = ? OR expires_at < NOW()")
+           ->execute([$userId]);
 
-    $db->prepare("INSERT INTO remember_tokens (user_id, token_hash, expires_at) VALUES (?,?,?)")
-       ->execute([$userId, $hash, $exp]);
+        $db->prepare("INSERT INTO remember_tokens (user_id, token_hash, expires_at) VALUES (?,?,?)")
+           ->execute([$userId, $hash, $exp]);
 
-    setcookie(REMEMBER_COOKIE, $userId . ':' . $token, [
-        'expires'  => time() + 86400 * REMEMBER_DAYS,
-        'path'     => '/',
-        'domain'   => '.besix.cz',
-        'secure'   => true,
-        'httponly' => true,
-        'samesite' => 'Lax',
-    ]);
+        setcookie(REMEMBER_COOKIE, $userId . ':' . $token, [
+            'expires'  => time() + 86400 * REMEMBER_DAYS,
+            'path'     => '/',
+            'domain'   => '.besix.cz',
+            'secure'   => true,
+            'httponly' => true,
+            'samesite' => 'Lax',
+        ]);
+    } catch (\Throwable $e) {
+        // Remember token is non-critical – login still succeeds without it
+        error_log('setRememberCookie failed: ' . $e->getMessage());
+    }
 }
 
 /**

--- a/setup.sql
+++ b/setup.sql
@@ -34,3 +34,15 @@ CREATE TABLE IF NOT EXISTS plan_backgrounds (
   updated_at    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   PRIMARY KEY (project_id, level_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ============================================================
+-- Remember-me tokens – trvalé přihlášení (30 dní)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS remember_tokens (
+  id         INT AUTO_INCREMENT PRIMARY KEY,
+  user_id    INT NOT NULL,
+  token_hash CHAR(64) NOT NULL,
+  expires_at DATETIME NOT NULL,
+  INDEX idx_tok (token_hash),
+  INDEX idx_uid (user_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
setRememberCookie() was calling _ensureRememberTable() which runs CREATE TABLE — if the DB user lacks CREATE privilege it threw an uncaught PDOException → 500 on the google_callback redirect.

Fix: wrap entire setRememberCookie() body in try/catch so a DB error never prevents login from completing. Cookie is silently skipped and an error_log entry is written instead.

Also: add remember_tokens table to setup.sql so the admin can pre-create it (granting the DB user proper access) which makes the remember-me feature fully operational.

https://claude.ai/code/session_012HVqboJ7mXP1ZqCRQNPMxc