### PR TITLE
Swap firma/profese columns: firma with dot on left, profese on right

### DIFF
--- a/index.html
+++ b/index.html
@@ -1765,6 +1765,8 @@ option { background: var(--card); color: var(--text); }
   font-size: 12px;
   color: var(--text-dim);
   font-family: var(--font-main);
+  min-width: 90px;
+  text-align: right;
 }
 .profese-row-actions {
   display: flex;
@@ -3311,8 +3313,8 @@ th.sort-desc .sort-arrow::after { content: '▼'; opacity: 1; }
       <thead>
         <tr>
           <th class="th-sort" data-sort="annotId">ID <span class="sort-arrow"></span></th>
-          <th class="th-sort" data-sort="profese">Profese <span class="sort-arrow"></span></th>
           <th class="th-sort" data-sort="firma">Firma <span class="sort-arrow"></span></th>
+          <th class="th-sort" data-sort="profese">Profese <span class="sort-arrow"></span></th>
           <th class="th-sort ac-popisek" data-sort="popisek">Popis <span class="sort-arrow"></span></th>
           <th class="th-sort" data-sort="levelName">Podlaží <span class="sort-arrow"></span></th>
           <th class="th-sort" data-sort="priorita">Priorita <span class="sort-arrow"></span></th>
@@ -7290,8 +7292,8 @@ function renderAnotacePage() {
     ).join('');
     return `<tr data-annot-id="${escHtml(r.annotId)}" data-level-idx="${r.levelIdx}">
       <td class="tcell-id">${escHtml(r.annotId)}</td>
-      <td><span class="tcell-prof"><span class="tcell-prof-dot" style="background:${color}"></span>${escHtml(r.profese||'—')}</span></td>
-      <td>${escHtml(r.firma||'—')}</td>
+      <td><span class="tcell-prof"><span class="tcell-prof-dot" style="background:${color}"></span>${escHtml(r.firma||'—')}</span></td>
+      <td>${escHtml(r.profese||'—')}</td>
       <td class="ac-popisek" title="${escHtml(r.popisek||'')}">${escHtml(r.popisek || '(bez popisu)')}</td>
       <td><span class="tcell-level">${escHtml(r.levelName)}</span></td>
       <td><span class="tcell-prio ${prioClass}">${escHtml(r.priorita||'Střední')}</span></td>
@@ -8419,8 +8421,8 @@ function renderProfeseList() {
     row.innerHTML = `
       <div class="profese-row-summary">
         <div class="profese-row-dot" style="background:${escHtml(prof.color)}"></div>
-        <div class="profese-row-name">${escHtml(prof.name)}</div>
-        <div class="profese-row-firma">${escHtml(prof.firma) || ''}</div>
+        <div class="profese-row-name">${escHtml(prof.firma || prof.name)}</div>
+        <div class="profese-row-firma">${escHtml(prof.name)}</div>
         <div class="profese-row-actions">
           <button class="profese-action-btn prof-edit-btn" data-idx="${idx}">Upravit</button>
           <button class="profese-action-btn danger prof-delete-btn" data-idx="${idx}">Smazat</button>


### PR DESCRIPTION
In anotace table: firma column (with colored dot) moved to left of profese column.
In manage profese list: show firma as primary label (dot+bold), profese as secondary.

https://claude.ai/code/session_012HVqboJ7mXP1ZqCRQNPMxc