### PR TITLE
Freeze existing annotations while drawing new shapes

### DIFF
--- a/index.html
+++ b/index.html
@@ -4420,6 +4420,15 @@ function setTool(tool) {
   }
 
   document.getElementById('status-tool-info').textContent = 'Nástroj: ' + (TOOL_NAMES[tool] || tool);
+
+  // Freeze existing annotations while any drawing tool is active
+  const isDrawing = (tool !== 'select' && tool !== 'pan');
+  fabricCanvas.getObjects().forEach(o => {
+    if (!o.annotId || o.isBackground || o.annotLabelFor) return;
+    o.selectable = !isDrawing;
+    o.evented = !isDrawing;
+  });
+
   fabricCanvas.renderAll();
 }
 


### PR DESCRIPTION
When any drawing tool is active, set selectable/evented=false on all annotation objects so accidental clicks/drags don't move them. Restored to interactive when switching back to select or pan mode.

https://claude.ai/code/session_012HVqboJ7mXP1ZqCRQNPMxc