### PR TITLE
Double-click shape editing, teardrop pin, two-click partition line

### DIFF
--- a/index.html
+++ b/index.html
@@ -4620,11 +4620,40 @@ function findLabel(annotId) {
 const LABEL_COMPACT_ZOOM = 2.0; // below this threshold show only contractor name
 let _labelsCompact = null;       // tracks current label mode to detect threshold crossing
 
+// Returns canvas-space midpoint along the arc of a Fabric Polyline/Polygon.
+function _polylineMidpoint(obj) {
+  const pts = obj.points;
+  if (!pts || pts.length === 0) return obj.getCenterPoint();
+  const matrix = obj.calcTransformMatrix();
+  const off = obj.pathOffset || { x: 0, y: 0 };
+  const cp = pts.map(p =>
+    fabric.util.transformPoint({ x: p.x - off.x, y: p.y - off.y }, matrix)
+  );
+  let total = 0;
+  for (let i = 1; i < cp.length; i++) {
+    total += Math.hypot(cp[i].x - cp[i-1].x, cp[i].y - cp[i-1].y);
+  }
+  let rem = total / 2;
+  for (let i = 1; i < cp.length; i++) {
+    const dx = cp[i].x - cp[i-1].x, dy = cp[i].y - cp[i-1].y;
+    const seg = Math.hypot(dx, dy);
+    if (rem <= seg) {
+      const t = seg > 0 ? rem / seg : 0;
+      return { x: cp[i-1].x + t * dx, y: cp[i-1].y + t * dy };
+    }
+    rem -= seg;
+  }
+  return cp[cp.length - 1];
+}
+
 function positionLabel(label, obj) {
   if (!label || !obj) return;
   const zoom = fabricCanvas.getZoom();
   const s = 1 / zoom;
-  const c = obj.getCenterPoint();
+  const type = obj.annotType || obj.type;
+  const c = (type === 'polyline' || type === 'partition') && obj.points
+    ? _polylineMidpoint(obj)
+    : obj.getCenterPoint();
   const lw = label.width  || 80;
   const lh = label.height || 34;
   label.set({

--- a/index.html
+++ b/index.html
@@ -3660,10 +3660,12 @@ let filterProfese = '', filterStatus = '';
 let contextMenuTarget = null;
 let pendingModalResolve = null;
 let _isProjectLoading = false;
-// Move-mode: annotation temporarily unlocked for drag after double-click
+// Move/edit-mode: annotation temporarily unlocked for drag/reshape after double-click
 let _moveAnnot = null;
 let _lastMoveClickTarget = null;
 let _lastMoveClickTime = 0;
+// Partition tool two-click state
+let partitionStartPt = null;
 
 // ============================================================
 // INIT
@@ -4394,6 +4396,11 @@ function setTool(tool) {
   if ((appState.tool === 'polygon' || appState.tool === 'polyline') && tool !== appState.tool) {
     cancelPolygon();
   }
+  if (appState.tool === 'partition' && tool !== 'partition' && partitionStartPt) {
+    partitionStartPt = null;
+    if (tempShape) { fabricCanvas.remove(tempShape); tempShape = null; }
+    fabricCanvas.renderAll();
+  }
   appState.tool = tool;
   // Update UI
   document.querySelectorAll('.tool-btn').forEach(btn => {
@@ -4828,20 +4835,80 @@ function cleanupOrphanedHelpers() {
   polyPoints = [];
 }
 
+function _enableVertexControls(poly) {
+  if (!poly.points || !poly.points.length) return;
+  poly.controls = {};
+  poly.cornerStyle = 'circle';
+  poly.cornerColor = '#fff';
+  poly.cornerStrokeColor = 'rgba(0,0,0,0.6)';
+  poly.cornerSize = 10;
+  poly.transparentCorners = false;
+  poly.hasControls = true;
+  poly.points.forEach((_, i) => {
+    poly.controls['p' + i] = new fabric.Control({
+      pointIndex: i,
+      positionHandler(dim, fm, obj) {
+        const pt = obj.points[this.pointIndex];
+        return fabric.util.transformPoint(
+          { x: pt.x - obj.pathOffset.x, y: pt.y - obj.pathOffset.y },
+          fabric.util.multiplyTransformMatrices(
+            obj.canvas.viewportTransform, obj.calcTransformMatrix()
+          )
+        );
+      },
+      actionHandler(ev, transform, x, y) {
+        const poly = transform.target;
+        const idx = poly.controls[poly.__corner].pointIndex;
+        const local = poly.toLocalPoint(new fabric.Point(x, y), 'center', 'center');
+        const base = poly._getNonTransformedDimensions();
+        const size = poly._getTransformedDimensions(0, 0);
+        poly.points[idx] = {
+          x: local.x * base.x / size.x + poly.pathOffset.x,
+          y: local.y * base.y / size.y + poly.pathOffset.y,
+        };
+        return true;
+      },
+      actionName: 'modifyPolygon',
+      cursorStyle: 'crosshair',
+    });
+  });
+}
+
 function _enterMoveMode(obj) {
   if (_moveAnnot && _moveAnnot !== obj) _exitMoveMode();
   _moveAnnot = obj;
   obj.set({ lockMovementX: false, lockMovementY: false });
+
+  const type = obj.annotType || obj.type;
+  if ((type === 'polygon' || type === 'polyline' || type === 'partition') && obj.points) {
+    _enableVertexControls(obj);
+  } else if (type !== 'pin' && type !== 'text' && type !== 'arrow') {
+    // rect, circle, freehand: show resize handles, hide rotation
+    obj.set({ hasControls: true, lockScalingX: false, lockScalingY: false });
+    obj.setControlVisible('mtr', false);
+  }
+
+  obj.setCoords();
   fabricCanvas.hoverCursor = 'move';
+  fabricCanvas.renderAll();
 }
 
 function _exitMoveMode() {
   if (!_moveAnnot) return;
-  _moveAnnot.set({ lockMovementX: true, lockMovementY: true });
+  const obj = _moveAnnot;
+  obj.set({
+    lockMovementX: true, lockMovementY: true,
+    lockScalingX: true,  lockScalingY: true,
+    hasControls: false,
+  });
+  obj.controls = fabric.Object.prototype.controls;
+  obj.cornerStyle = 'rect';
+  obj.setCoords();
   _moveAnnot = null;
   if (appState.tool === 'select') fabricCanvas.hoverCursor = 'pointer';
   _lastMoveClickTarget = null;
   _lastMoveClickTime = 0;
+  fabricCanvas.renderAll();
 }
 
 // Apply lock properties to all existing annotations (called after loadFromJSON/undo/redo)
@@ -4975,24 +5042,43 @@ function setupEventListeners() {
     const color = getActiveProfeseColor();
 
     if (appState.tool === 'pin') {
-      // Place pin immediately
       isDrawing = false;
       placePinAt(pointer.x, pointer.y);
     } else if (appState.tool === 'text') {
       isDrawing = false;
       placeTextAt(pointer.x, pointer.y);
     } else if (appState.tool === 'partition') {
-      tempShape = new fabric.Rect({
-        left: pointer.x, top: pointer.y,
-        width: 1, height: 1,
-        fill: color + '66',
-        stroke: color,
-        strokeWidth: 2,
-        strokeUniform: true,
-        selectable: false, evented: false,
-        originX: 'left', originY: 'top'
-      });
-      cw.add(tempShape);
+      isDrawing = false;
+      if (!partitionStartPt) {
+        // First click — store start, show a dot
+        partitionStartPt = { x: pointer.x, y: pointer.y };
+        tempShape = new fabric.Circle({
+          left: pointer.x, top: pointer.y, radius: 4,
+          fill: color, stroke: '#fff', strokeWidth: 1,
+          originX: 'center', originY: 'center',
+          selectable: false, evented: false
+        });
+        cw.add(tempShape);
+      } else {
+        // Second click — finalize line
+        const start = partitionStartPt;
+        partitionStartPt = null;
+        if (tempShape) { cw.remove(tempShape); tempShape = null; }
+        const line = new fabric.Polyline(
+          [{ x: start.x, y: start.y }, { x: pointer.x, y: pointer.y }],
+          { stroke: color, strokeWidth: 5, fill: 'transparent',
+            strokeLineCap: 'round', strokeLineJoin: 'round' }
+        );
+        addAnnotationProperties(line, 'partition');
+        cw.add(line);
+        createAnnotLabel(line);
+        cw.setActiveObject(line);
+        pushUndoState();
+        updateAnnotList();
+        onObjectSelected({ target: line });
+        saveCurrentLevel();
+        setTool('select');
+      }
     } else if (appState.tool === 'rect') {
       tempShape = new fabric.Rect({
         left: pointer.x, top: pointer.y,
@@ -5054,12 +5140,30 @@ function setupEventListeners() {
       return;
     }
 
+    // Partition two-click: show preview line from start to cursor
+    if (appState.tool === 'partition' && partitionStartPt) {
+      const color = getActiveProfeseColor();
+      if (tempShape && tempShape.type !== 'line') {
+        fabricCanvas.remove(tempShape);
+        tempShape = new fabric.Line(
+          [partitionStartPt.x, partitionStartPt.y, pointer.x, pointer.y],
+          { stroke: color, strokeWidth: 5, strokeLineCap: 'round',
+            selectable: false, evented: false }
+        );
+        fabricCanvas.add(tempShape);
+      } else if (tempShape) {
+        tempShape.set({ x2: pointer.x, y2: pointer.y });
+      }
+      fabricCanvas.renderAll();
+      return;
+    }
+
     if (!isDrawing || !tempShape) return;
 
     const dx = pointer.x - drawStartX;
     const dy = pointer.y - drawStartY;
 
-    if (appState.tool === 'rect' || appState.tool === 'partition') {
+    if (appState.tool === 'rect') {
       const left = dx < 0 ? pointer.x : drawStartX;
       const top = dy < 0 ? pointer.y : drawStartY;
       tempShape.set({ left, top, width: Math.abs(dx), height: Math.abs(dy) });
@@ -5105,26 +5209,7 @@ function setupEventListeners() {
 
     const color = getActiveProfeseColor();
 
-    if (appState.tool === 'partition') {
-      const left = dx < 0 ? pointer.x : drawStartX;
-      const top = dy < 0 ? pointer.y : drawStartY;
-      const wall = new fabric.Rect({
-        left, top,
-        width: Math.abs(dx), height: Math.abs(dy),
-        fill: color + '66',
-        stroke: color,
-        strokeWidth: 2,
-        strokeUniform: true
-      });
-      addAnnotationProperties(wall, 'partition');
-      cw.add(wall);
-      createAnnotLabel(wall);
-      cw.setActiveObject(wall);
-      pushUndoState();
-      updateAnnotList();
-      onObjectSelected({ target: wall });
-      setTool('select');
-    } else if (appState.tool === 'rect') {
+    if (appState.tool === 'rect') {
       const left = dx < 0 ? pointer.x : drawStartX;
       const top = dy < 0 ? pointer.y : drawStartY;
       const rect = new fabric.Rect({
@@ -5219,10 +5304,7 @@ function setupEventListeners() {
   // Object modified
   cw.on('object:modified', (opt) => {
     const obj = opt && opt.target;
-    if (obj && obj.annotId) {
-      positionLabel(findLabel(obj.annotId), obj);
-      if (obj === _moveAnnot) _exitMoveMode();
-    }
+    if (obj && obj.annotId) positionLabel(findLabel(obj.annotId), obj);
     pushUndoState();
     saveCurrentLevel();
   });
@@ -5726,18 +5808,14 @@ function onKeyUp(e) { /* handled in main listener */ }
 // ============================================================
 function placePinAt(x, y) {
   const color = getActiveProfeseColor();
-  const pin = new fabric.Group([
-    new fabric.Circle({
-      radius: 10, fill: color, stroke: '#fff', strokeWidth: 1.5,
-      left: -10, top: -20
-    }),
-    new fabric.Triangle({
-      width: 12, height: 8, fill: color,
-      left: -6, top: -4
-    })
-  ], {
-    left: x, top: y, originX: 'center', originY: 'bottom',
-    hasControls: true, selectable: true
+  // Teardrop pointing down: tip at (0,0), circle head above centered at (0,-18) r=12
+  const d = 'M 0 0 C -11 -4 -12 -11 -12 -18 A 12 12 0 1 1 12 -18 C 12 -11 11 -4 0 0 Z';
+  const pin = new fabric.Path(d, {
+    left: x, top: y,
+    originX: 'center', originY: 'bottom',
+    fill: color,
+    stroke: 'rgba(0,0,0,0.25)', strokeWidth: 0.5,
+    selectable: true,
   });
   addAnnotationProperties(pin, 'pin');
   fabricCanvas.add(pin);


### PR DESCRIPTION
Shape editing after double-click:
- Polygon/polyline/partition: vertex handles appear at each point, drag any vertex to reshape (Fabric.Control with per-pixel positionHandler)
- Rect/circle/freehand: resize handles shown (no rotation), locked again on exit
- Move (lockMovementX/Y) also unlocked in same mode
- Exit on Escape, click elsewhere, or tool switch; stays in edit mode after vertex/drag so user can reshape multiple vertices in one session

Pin simplified:
- fabric.Group replaced with fabric.Path teardrop (kapička) pointing down
- Single color = supplier color, subtle dark border, tip at click point

Partition fixed as two-click line:
- First click sets start point (shows dot preview)
- Mouse move shows live line preview
- Second click creates thick Polyline (strokeWidth 5, rounded caps)
- Escape / tool switch cancels the in-progress line
- Removed old drag-rect code from mouse:up

https://claude.ai/code/session_012HVqboJ7mXP1ZqCRQNPMxc