### PR TITLE
Reduce annotation list PDF font sizes by 30%

### DIFF
--- a/index.html
+++ b/index.html
@@ -7965,8 +7965,8 @@ function drawAnnotListToPDF(pdf, anns, lx, ly, lw, lh, targetCount) {
 
   // Layout constants (mm)
   const TITLE_H  = 8,   COLH_H  = 5;
-  const DOT_R    = 1,   ROW_MAX = 5;
-  const BADGE_FS = 7;   // pt — badge / row text cap
+  const DOT_R    = 0.7, ROW_MAX = 3.5;
+  const BADGE_FS = 5;   // pt — badge / row text cap
 
   const C_DOT  = lx + 0.012 * lw;
   const C_ID   = lx + 0.045 * lw;
@@ -7983,7 +7983,7 @@ function drawAnnotListToPDF(pdf, anns, lx, ly, lw, lh, targetCount) {
   pdf.setFillColor(28, 34, 20);
   pdf.rect(lx, ly, lw, TITLE_H, 'F');
   pdf.setFont('helvetica', 'bold');
-  pdf.setFontSize(10);
+  pdf.setFontSize(7);
   pdf.setTextColor(160, 196, 100);
   pdf.text('ANOTACE', lx + lw * 0.02, ly + TITLE_H * 0.70);
 
@@ -8009,7 +8009,7 @@ function drawAnnotListToPDF(pdf, anns, lx, ly, lw, lh, targetCount) {
 
   // ── Column headers ──
   const colBaseY = ly + TITLE_H + COLH_H - 0.8;
-  pdf.setFont('helvetica', 'normal'); pdf.setFontSize(6); pdf.setTextColor(100, 120, 80);
+  pdf.setFont('helvetica', 'normal'); pdf.setFontSize(4); pdf.setTextColor(100, 120, 80);
   pdf.text('ID',           C_ID,    colBaseY);
   pdf.text('Subdodavatel', C_PROF,  colBaseY);
   pdf.text('Popis',        C_POPIS, colBaseY);
@@ -8034,9 +8034,9 @@ function drawAnnotListToPDF(pdf, anns, lx, ly, lw, lh, targetCount) {
     return { rows, totalH: rows.reduce((s, r) => s + r.rowH, 0) };
   };
 
-  let rowFS = Math.max(4, Math.min(BADGE_FS, Math.round(availH / Math.max(1, refCount) / 1.7 * PT_MM)));
+  let rowFS = Math.max(3, Math.min(BADGE_FS, Math.round(availH / Math.max(1, refCount) / 1.7 * PT_MM)));
   let layout = computeLayout(rowFS);
-  while (layout.totalH > availH && rowFS > 4) { rowFS--; layout = computeLayout(rowFS); }
+  while (layout.totalH > availH && rowFS > 3) { rowFS--; layout = computeLayout(rowFS); }
 
   // ── Render rows ──
   let curY = ROWS_START;


### PR DESCRIPTION
BADGE_FS 7→5pt, title 10→7pt, column headers 6→4pt, rowFS min 4→3, DOT_R 1→0.7mm, ROW_MAX 5→3.5mm.

https://claude.ai/code/session_012HVqboJ7mXP1ZqCRQNPMxc