### PR TITLE
KD: server persistence + major redesign

### DIFF
--- a/index.html
+++ b/index.html
@@ -1412,45 +1412,92 @@ option { background: var(--card); color: var(--text); }
   display: none; position: fixed;
   top: 48px; left: 0; right: 0; bottom: 26px;
   z-index: 102;
-  background: var(--bg); flex-direction: column; overflow: hidden;
+  background: var(--bg); flex-direction: row; overflow: hidden;
 }
 #kd-page.visible { display: flex; }
-#kd-header {
-  display: flex; align-items: center; gap: 10px;
-  padding: 0 14px; height: 44px; flex-shrink: 0;
-  background: var(--panel); border-bottom: 1px solid var(--border);
+
+/* Sidebar */
+#kd-sidebar {
+  width: 220px; min-width: 220px; flex-shrink: 0;
+  background: var(--panel); border-right: 1px solid var(--border);
+  display: flex; flex-direction: column; overflow: hidden;
+}
+#kd-sidebar-top {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 0 10px; height: 44px; flex-shrink: 0;
+  border-bottom: 1px solid var(--border);
 }
 .kd-page-title {
   font-family: var(--font-mono); font-size: 12px; font-weight: 700;
-  color: var(--text-bright); white-space: nowrap; margin-right: 4px;
+  color: var(--text-bright); white-space: nowrap;
 }
-#kd-record-tabs {
-  display: flex; gap: 4px; overflow-x: auto; flex: 1; align-items: center;
-  scrollbar-width: none;
-}
-#kd-record-tabs::-webkit-scrollbar { display: none; }
-.kd-tab {
-  padding: 3px 10px; border-radius: 4px; font-size: 11px;
-  border: 1px solid var(--border); cursor: pointer; white-space: nowrap;
-  background: var(--card); color: var(--text); font-family: var(--font-mono);
-  transition: background 0.12s;
-}
-.kd-tab.active { background: var(--olive); color: #fff; border-color: var(--olive); }
-.kd-tab:not(.active):hover { border-color: var(--olive-light); }
-#kd-new-record-btn {
-  padding: 4px 10px; border-radius: 4px; font-size: 11px;
-  background: transparent; border: 1px dashed var(--border);
-  color: var(--text-dim); cursor: pointer; white-space: nowrap; flex-shrink: 0;
-  font-family: var(--font-main);
-}
-#kd-new-record-btn:hover { border-color: var(--olive); color: var(--olive); border-style: solid; }
 #kd-close-btn {
-  width: 26px; height: 26px; border-radius: 4px; flex-shrink: 0;
+  width: 24px; height: 24px; border-radius: 4px; flex-shrink: 0;
   background: transparent; border: 1px solid var(--border);
   color: var(--text-dim); cursor: pointer; font-size: 15px;
   display: flex; align-items: center; justify-content: center;
 }
 #kd-close-btn:hover { background: var(--card); color: var(--text-bright); }
+#kd-new-record-btn {
+  margin: 10px 10px 6px; padding: 6px 10px; border-radius: 5px; font-size: 11px;
+  background: rgba(74,83,64,0.12); border: 1px solid var(--border);
+  color: var(--olive-light); cursor: pointer; font-family: var(--font-main);
+  text-align: center; font-weight: 600; transition: background 0.12s;
+}
+#kd-new-record-btn:hover { background: rgba(74,83,64,0.25); color: var(--text-bright); border-color: var(--olive); }
+#kd-record-list {
+  flex: 1; overflow-y: auto; padding: 2px 6px;
+  display: flex; flex-direction: column; gap: 2px;
+}
+#kd-record-list::-webkit-scrollbar { width: 4px; }
+#kd-record-list::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
+.kd-rec-item {
+  display: flex; align-items: center; gap: 5px;
+  padding: 5px 7px; border-radius: 5px; cursor: pointer;
+  border: 1px solid transparent; transition: background 0.1s;
+}
+.kd-rec-item:hover { background: var(--card); border-color: var(--border); }
+.kd-rec-item.active { background: rgba(74,83,64,0.18); border-color: var(--olive); }
+.kd-rec-item-date {
+  flex: 1; font-family: var(--font-mono); font-size: 11px; color: var(--text);
+}
+.kd-rec-item.active .kd-rec-item-date { color: var(--text-bright); font-weight: 700; }
+.kd-rec-item-del {
+  width: 16px; height: 16px; border-radius: 3px; border: none;
+  background: transparent; color: transparent; cursor: pointer;
+  font-size: 11px; display: flex; align-items: center; justify-content: center;
+  flex-shrink: 0; transition: color 0.1s, background 0.1s;
+}
+.kd-rec-item:hover .kd-rec-item-del { color: var(--text-dim); }
+.kd-rec-item-del:hover { background: rgba(239,68,68,0.1) !important; color: #EF4444 !important; }
+
+/* Backup section */
+#kd-backup-section {
+  padding: 10px; border-top: 1px solid var(--border); flex-shrink: 0;
+}
+.kd-backup-title {
+  font-size: 10px; font-weight: 700; color: var(--text-dim);
+  text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 7px;
+  font-family: var(--font-mono);
+}
+.kd-backup-row {
+  display: flex; align-items: center; gap: 6px; margin-bottom: 5px;
+}
+.kd-backup-label { font-size: 10px; color: var(--text-dim); width: 28px; flex-shrink: 0; }
+#kd-backup-day, #kd-backup-time {
+  flex: 1; padding: 3px 5px; border: 1px solid var(--border); border-radius: 3px;
+  background: var(--card); color: var(--text); font-size: 10px;
+  font-family: var(--font-mono);
+}
+#kd-backup-next {
+  font-size: 10px; color: var(--text-dim); margin-top: 4px; line-height: 1.4;
+  font-family: var(--font-mono);
+}
+
+/* Main content area */
+#kd-main {
+  flex: 1; display: flex; flex-direction: column; overflow: hidden; min-width: 0;
+}
 #kd-meta-bar {
   display: flex; align-items: center; gap: 10px;
   padding: 7px 14px; background: var(--panel);
@@ -1486,7 +1533,7 @@ option { background: var(--card); color: var(--text); }
 .kd-empty-title { font-size: 14px; font-weight: 600; color: var(--text); }
 .kd-empty-sub { font-size: 12px; }
 .kd-card {
-  width: 280px; min-width: 280px; background: var(--panel);
+  width: 300px; min-width: 300px; background: var(--panel);
   border: 1px solid var(--border); border-radius: 8px;
   display: flex; flex-direction: column; flex-shrink: 0;
   max-height: calc(100vh - 160px); box-shadow: 0 1px 4px rgba(0,0,0,0.06);
@@ -1519,7 +1566,7 @@ option { background: var(--card); color: var(--text); }
 }
 .kd-task {
   background: var(--card); border: 1px solid var(--border);
-  border-radius: 5px; padding: 6px 7px; display: flex; flex-direction: column; gap: 3px;
+  border-radius: 5px; padding: 6px 7px; display: flex; flex-direction: column; gap: 4px;
 }
 .kd-task-row1 { display: flex; align-items: flex-start; gap: 4px; }
 .kd-task-text {
@@ -1536,7 +1583,20 @@ option { background: var(--card); color: var(--text); }
 }
 .kd-task-btn:hover { background: var(--panel); color: var(--text); }
 .kd-task-btn.kdel:hover { color: #EF4444; background: rgba(239,68,68,0.08); }
-.kd-task-row2 { display: flex; align-items: center; gap: 4px; flex-wrap: wrap; }
+.kd-task-row2 {
+  display: flex; align-items: center; gap: 4px; flex-wrap: wrap;
+}
+.kd-task-dates {
+  display: flex; align-items: center; gap: 3px; flex-wrap: nowrap; flex-shrink: 0;
+}
+.kd-task-date-label { font-size: 9px; color: var(--text-dim); font-family: var(--font-mono); white-space: nowrap; }
+.kd-task-date-input {
+  width: 88px; padding: 2px 4px; border: 1px solid var(--border); border-radius: 3px;
+  background: var(--bg); color: var(--text); font-size: 10px;
+  font-family: var(--font-mono);
+}
+.kd-task-date-input:focus { outline: none; border-color: var(--olive); }
+.kd-task-date-sep { font-size: 10px; color: var(--text-dim); }
 .kd-task-sub-chip {
   display: inline-flex; align-items: center; gap: 3px;
   padding: 1px 6px 1px 4px; border-radius: 10px; font-size: 10px;
@@ -1567,7 +1627,7 @@ option { background: var(--card); color: var(--text); }
 }
 .kd-add-task-btn:hover { border-color: var(--olive); color: var(--olive); background: rgba(74,83,64,0.04); }
 .kd-add-card-btn {
-  width: 260px; min-width: 260px; height: 50px; flex-shrink: 0;
+  width: 280px; min-width: 280px; height: 50px; flex-shrink: 0;
   border: 2px dashed var(--border); border-radius: 8px;
   background: transparent; color: var(--text-dim); cursor: pointer;
   font-size: 12px; display: flex; align-items: center; justify-content: center;
@@ -3564,26 +3624,52 @@ th.sort-desc .sort-arrow::after { content: '▼'; opacity: 1; }
 
 <!-- KONTROLNÍ DEN PAGE -->
 <div id="kd-page">
-  <div id="kd-header">
-    <span class="kd-page-title">Kontrolní den</span>
-    <div id="kd-record-tabs"></div>
-    <button id="kd-new-record-btn">+ Nový záznam</button>
-    <button id="kd-close-btn">×</button>
-  </div>
-  <div id="kd-meta-bar" style="display:none">
-    <span class="kd-meta-label">Datum</span>
-    <input type="date" id="kd-date-input">
-    <span class="kd-meta-label">Poznámka</span>
-    <input type="text" id="kd-note-input" placeholder="Obecná poznámka k zápisu...">
-    <button id="kd-delete-record-btn">Smazat záznam</button>
-  </div>
-  <div id="kd-body">
-    <div id="kd-empty-state">
-      <div class="kd-empty-icon">📋</div>
-      <div class="kd-empty-title">Žádný záznam z kontrolního dne</div>
-      <div class="kd-empty-sub">Klikněte na „+ Nový záznam" pro vytvoření zápisu</div>
+  <!-- Left sidebar -->
+  <div id="kd-sidebar">
+    <div id="kd-sidebar-top">
+      <span class="kd-page-title">Kontrolní den</span>
+      <button id="kd-close-btn" title="Zavřít">×</button>
     </div>
-    <div id="kd-cards-scroll" style="display:none"></div>
+    <button id="kd-new-record-btn">+ Nový záznam</button>
+    <div id="kd-record-list"></div>
+    <div id="kd-backup-section">
+      <div class="kd-backup-title">Automatická záloha</div>
+      <div class="kd-backup-row">
+        <label class="kd-backup-label">Den</label>
+        <select id="kd-backup-day">
+          <option value="0">Neděle</option>
+          <option value="1">Pondělí</option>
+          <option value="2">Úterý</option>
+          <option value="3">Středa</option>
+          <option value="4">Čtvrtek</option>
+          <option value="5">Pátek</option>
+          <option value="6">Sobota</option>
+        </select>
+      </div>
+      <div class="kd-backup-row">
+        <label class="kd-backup-label">Čas</label>
+        <input type="time" id="kd-backup-time" value="23:59">
+      </div>
+      <div id="kd-backup-next"></div>
+    </div>
+  </div>
+  <!-- Main content -->
+  <div id="kd-main">
+    <div id="kd-meta-bar" style="display:none">
+      <span class="kd-meta-label">Datum</span>
+      <input type="date" id="kd-date-input">
+      <span class="kd-meta-label">Poznámka</span>
+      <input type="text" id="kd-note-input" placeholder="Obecná poznámka k zápisu...">
+      <button id="kd-delete-record-btn">Smazat záznam</button>
+    </div>
+    <div id="kd-body">
+      <div id="kd-empty-state">
+        <div class="kd-empty-icon">📋</div>
+        <div class="kd-empty-title">Žádný záznam z kontrolního dne</div>
+        <div class="kd-empty-sub">Klikněte na „+ Nový záznam" pro vytvoření zápisu</div>
+      </div>
+      <div id="kd-cards-scroll" style="display:none"></div>
+    </div>
   </div>
 </div>
 
@@ -8775,7 +8861,8 @@ function _buildStateObj() {
     activeLevel: appState.activeLevel,
     tool: appState.tool,
     showGrid: appState.showGrid,
-    zones3D: appState.zones3D
+    zones3D: appState.zones3D,
+    kdRecords: kdRecords
   };
 }
 
@@ -9264,11 +9351,17 @@ function renderHomePage() {
 // KONTROLNÍ DEN
 // ============================================================
 const LS_KD_KEY = (pid) => `besix_plans_kd_${pid}`;
-let kdRecords   = [];    // [{id,date,note,cards:[{id,title,tasks:[{id,text,sub,links:[]}]}]}]
+const LS_KD_BACKUP_SCHED = (pid) => `besix_kd_backup_sched_${pid}`;
+const LS_KD_BACKUPS = (pid) => `besix_kd_backups_${pid}`;
+
+let kdRecords   = [];    // [{id,date,note,cards:[{id,title,tasks:[{id,text,sub,dateFrom,dateTo,links:[]}]}]}]
 let kdActiveId  = null;
 let _kdLinkRec  = null;
 let _kdLinkTaskId = null;
 let _kdSubCloseHandler = null;
+let _kdBackupSchedule = { day: 0, time: '23:59' }; // day: 0=Sun..6=Sat
+let _kdLastBackupCheck = null;
+let _kdBackupTimer = null;
 
 function kdGenId() { return Date.now().toString(36) + Math.random().toString(36).slice(2, 6); }
 
@@ -9276,6 +9369,7 @@ function kdSave() {
   const pid = currentProject?.id;
   if (!pid) return;
   localStorage.setItem(LS_KD_KEY(pid), JSON.stringify(kdRecords));
+  _serverSave();
 }
 
 function kdLoad() {
@@ -9286,6 +9380,63 @@ function kdLoad() {
   if (!Array.isArray(kdRecords)) kdRecords = [];
 }
 
+function kdLoadBackupSchedule() {
+  const pid = currentProject?.id; if (!pid) return;
+  try {
+    const s = JSON.parse(localStorage.getItem(LS_KD_BACKUP_SCHED(pid)) || 'null');
+    if (s && typeof s.day === 'number' && typeof s.time === 'string') _kdBackupSchedule = s;
+    else _kdBackupSchedule = { day: 0, time: '23:59' };
+  } catch { _kdBackupSchedule = { day: 0, time: '23:59' }; }
+}
+
+function kdSaveBackupSchedule() {
+  const pid = currentProject?.id; if (!pid) return;
+  try { localStorage.setItem(LS_KD_BACKUP_SCHED(pid), JSON.stringify(_kdBackupSchedule)); } catch(e) {}
+}
+
+function kdRunAutoBackup() {
+  const pid = currentProject?.id; if (!pid || !kdRecords.length) return;
+  const now = new Date();
+  const dayMatch = now.getDay() === _kdBackupSchedule.day;
+  const [hh, mm] = _kdBackupSchedule.time.split(':').map(Number);
+  const timeMatch = now.getHours() === hh && now.getMinutes() === mm;
+  const key = `${now.toISOString().slice(0,10)}_${_kdBackupSchedule.time}`;
+  if (dayMatch && timeMatch && _kdLastBackupCheck !== key) {
+    _kdLastBackupCheck = key;
+    kdDoBackup('Automatická záloha');
+  }
+  kdUpdateBackupNextLabel();
+}
+
+function kdDoBackup(label) {
+  const pid = currentProject?.id; if (!pid) return;
+  try {
+    let backups = JSON.parse(localStorage.getItem(LS_KD_BACKUPS(pid)) || '[]');
+    backups.push({ ts: Date.now(), label, data: JSON.stringify(kdRecords) });
+    if (backups.length > 12) backups = backups.slice(-12);
+    localStorage.setItem(LS_KD_BACKUPS(pid), JSON.stringify(backups));
+  } catch(e) {}
+}
+
+function kdNextBackupDate() {
+  const now = new Date();
+  const [hh, mm] = _kdBackupSchedule.time.split(':').map(Number);
+  const target = new Date(now);
+  target.setHours(hh, mm, 0, 0);
+  let diff = (_kdBackupSchedule.day - now.getDay() + 7) % 7;
+  if (diff === 0 && now >= target) diff = 7;
+  target.setDate(target.getDate() + diff);
+  return target;
+}
+
+function kdUpdateBackupNextLabel() {
+  const el = document.getElementById('kd-backup-next'); if (!el) return;
+  const next = kdNextBackupDate();
+  const dayNames = ['Ne','Po','Út','St','Čt','Pá','So'];
+  const d = `${dayNames[next.getDay()]} ${next.getDate()}.${next.getMonth()+1}. ${String(next.getHours()).padStart(2,'0')}:${String(next.getMinutes()).padStart(2,'0')}`;
+  el.textContent = 'Příští: ' + d;
+}
+
 function toggleKDPage() {
   const page = document.getElementById('kd-page');
   const btn  = document.getElementById('kd-btn');
@@ -9293,14 +9444,14 @@ function toggleKDPage() {
     page.classList.remove('visible'); btn.classList.remove('active');
   } else {
     closeAnotacePage(); toggleHomePage(false); toggleUsersPage(false);
-    kdLoad();
+    kdLoad(); kdLoadBackupSchedule();
     if (!kdActiveId && kdRecords.length) kdActiveId = kdRecords[kdRecords.length - 1].id;
     page.classList.add('visible'); btn.classList.add('active');
     kdRenderPage();
   }
 }
 
-function kdRenderPage() { kdRenderTabs(); kdRenderContent(); }
+function kdRenderPage() { kdRenderSidebar(); kdRenderContent(); }
 
 function kdFmtDate(d) {
   if (!d) return '–';
@@ -9308,16 +9459,36 @@ function kdFmtDate(d) {
   return p.length === 3 ? `${p[2]}.${p[1]}.${p[0].slice(2)}` : d;
 }
 
-function kdRenderTabs() {
-  const tabs = document.getElementById('kd-record-tabs');
-  tabs.innerHTML = '';
-  kdRecords.forEach(rec => {
-    const t = document.createElement('button');
-    t.className = 'kd-tab' + (rec.id === kdActiveId ? ' active' : '');
-    t.textContent = kdFmtDate(rec.date);
-    t.onclick = () => { kdActiveId = rec.id; kdRenderPage(); };
-    tabs.appendChild(t);
+function kdRenderSidebar() {
+  const list = document.getElementById('kd-record-list'); if (!list) return;
+  list.innerHTML = '';
+  // Sort records by date descending (newest first)
+  const sorted = [...kdRecords].sort((a, b) => (b.date || '') < (a.date || '') ? -1 : (b.date || '') > (a.date || '') ? 1 : 0);
+  sorted.forEach(rec => {
+    const item = document.createElement('div');
+    item.className = 'kd-rec-item' + (rec.id === kdActiveId ? ' active' : '');
+    const dateSpan = document.createElement('span');
+    dateSpan.className = 'kd-rec-item-date';
+    dateSpan.textContent = kdFmtDate(rec.date);
+    const delBtn = document.createElement('button');
+    delBtn.className = 'kd-rec-item-del'; delBtn.title = 'Smazat záznam'; delBtn.textContent = '✕';
+    delBtn.onclick = e => {
+      e.stopPropagation();
+      if (!confirm('Opravdu smazat tento záznam z kontrolního dne?')) return;
+      kdRecords = kdRecords.filter(r => r.id !== rec.id);
+      if (kdActiveId === rec.id) kdActiveId = kdRecords.length ? kdRecords[kdRecords.length - 1].id : null;
+      kdSave(); kdRenderPage();
+    };
+    item.appendChild(dateSpan); item.appendChild(delBtn);
+    item.onclick = () => { kdActiveId = rec.id; kdRenderPage(); };
+    list.appendChild(item);
   });
+  // Backup schedule controls
+  const dayEl = document.getElementById('kd-backup-day');
+  const timeEl = document.getElementById('kd-backup-time');
+  if (dayEl) dayEl.value = String(_kdBackupSchedule.day);
+  if (timeEl) timeEl.value = _kdBackupSchedule.time;
+  kdUpdateBackupNextLabel();
 }
 
 function kdRenderContent() {
@@ -9364,7 +9535,7 @@ function kdBuildCard(rec, card) {
   const inp = document.createElement('input');
   inp.className = 'kd-card-title'; inp.value = card.title || '';
   inp.placeholder = 'Název úseku...';
-  inp.onchange = () => { card.title = inp.value; kdSave(); kdRenderTabs(); };
+  inp.onchange = () => { card.title = inp.value; kdSave(); kdRenderSidebar(); };
   const cnt = document.createElement('span');
   cnt.className = 'kd-card-count'; cnt.textContent = (card.tasks || []).length;
   const del = document.createElement('button'); del.className = 'kd-card-del-btn';
@@ -9392,7 +9563,7 @@ function kdBuildTask(rec, card, task) {
   const r1 = document.createElement('div'); r1.className = 'kd-task-row1';
   const ta = document.createElement('textarea');
   ta.className = 'kd-task-text'; ta.value = task.text || '';
-  ta.placeholder = 'Popis úkolu...'; ta.rows = 1;
+  ta.placeholder = 'Název úkolu...'; ta.rows = 1;
   ta.oninput = () => {
     ta.style.height = 'auto'; ta.style.height = ta.scrollHeight + 'px';
     task.text = ta.value; kdSave();
@@ -9412,8 +9583,10 @@ function kdBuildTask(rec, card, task) {
   r1.appendChild(ta); r1.appendChild(acts);
   el.appendChild(r1);
 
-  // Row 2: subdodavatel chip + link chips
+  // Row 2: subdodavatel chip + dates + link chips
   const r2 = document.createElement('div'); r2.className = 'kd-task-row2';
+
+  // Supplier
   const prof = (appState.profese || []).find(p => p.name === task.sub);
   if (prof) {
     const chip = document.createElement('span');
@@ -9429,6 +9602,23 @@ function kdBuildTask(rec, card, task) {
     none.onclick = e => kdOpenSubPop(e, rec, task);
     r2.appendChild(none);
   }
+
+  // Date range
+  const dates = document.createElement('div'); dates.className = 'kd-task-dates';
+  const lblOd = document.createElement('span'); lblOd.className = 'kd-task-date-label'; lblOd.textContent = 'Od:';
+  const inpOd = document.createElement('input'); inpOd.type = 'date'; inpOd.className = 'kd-task-date-input';
+  inpOd.value = task.dateFrom || ''; inpOd.title = 'Datum od';
+  inpOd.onchange = () => { task.dateFrom = inpOd.value || null; kdSave(); };
+  const sep = document.createElement('span'); sep.className = 'kd-task-date-sep'; sep.textContent = '—';
+  const lblDo = document.createElement('span'); lblDo.className = 'kd-task-date-label'; lblDo.textContent = 'Do:';
+  const inpDo = document.createElement('input'); inpDo.type = 'date'; inpDo.className = 'kd-task-date-input';
+  inpDo.value = task.dateTo || ''; inpDo.title = 'Datum do';
+  inpDo.onchange = () => { task.dateTo = inpDo.value || null; kdSave(); };
+  dates.appendChild(lblOd); dates.appendChild(inpOd); dates.appendChild(sep);
+  dates.appendChild(lblDo); dates.appendChild(inpDo);
+  r2.appendChild(dates);
+
+  // Link chips
   (task.links || []).forEach(lid => {
     const found = kdAllTasks(rec).find(({task: t}) => t.id === lid);
     if (!found) return;
@@ -9451,7 +9641,7 @@ function kdAddCard(rec) {
 }
 
 function kdAddTask(rec, card) {
-  const task = { id: kdGenId(), text: '', sub: null, links: [] };
+  const task = { id: kdGenId(), text: '', sub: null, dateFrom: null, dateTo: null, links: [] };
   card.tasks.push(task); kdSave(); kdRenderContent();
   setTimeout(() => { const t = document.querySelector(`.kd-task[data-task-id="${task.id}"] .kd-task-text`); if (t) t.focus(); }, 60);
 }
@@ -9501,7 +9691,9 @@ function kdRenderLinkList(q) {
   const linked = new Set(src.task.links || []);
   const items = kdAllTasks(_kdLinkRec)
     .filter(({task}) => task.id !== _kdLinkTaskId)
-    .filter(({task}) => !q || (task.text || '').toLowerCase().includes(q.toLowerCase()) || (_kdLinkRec.cards.find(c=>c.id===task.id)?.title||'').toLowerCase().includes(q.toLowerCase()));
+    .filter(({task, card}) => !q ||
+      (task.text || '').toLowerCase().includes(q.toLowerCase()) ||
+      (card.title || '').toLowerCase().includes(q.toLowerCase()));
   if (!items.length) {
     list.innerHTML = '<div style="padding:12px;text-align:center;font-size:12px;color:var(--text-dim)">Žádné jiné úkoly</div>';
     return;
@@ -9511,8 +9703,18 @@ function kdRenderLinkList(q) {
     d.className = 'kd-link-item' + (linked.has(task.id) ? ' sel' : '');
     d.innerHTML = `<div class="kd-link-card-name">${card.title||'Bez názvu'}</div><div>${task.text||'(bez popisu)'}</div>`;
     d.onclick = () => {
-      if (linked.has(task.id)) { src.task.links = (src.task.links||[]).filter(id=>id!==task.id); linked.delete(task.id); d.classList.remove('sel'); }
-      else { src.task.links = [...(src.task.links||[]), task.id]; linked.add(task.id); d.classList.add('sel'); }
+      if (linked.has(task.id)) {
+        src.task.links = (src.task.links||[]).filter(id=>id!==task.id);
+        linked.delete(task.id); d.classList.remove('sel');
+      } else {
+        src.task.links = [...(src.task.links||[]), task.id];
+        linked.add(task.id); d.classList.add('sel');
+        // Auto-fill dates: if target has dates and source doesn't → copy
+        if ((task.dateFrom || task.dateTo) && !src.task.dateFrom && !src.task.dateTo) {
+          src.task.dateFrom = task.dateFrom || null;
+          src.task.dateTo = task.dateTo || null;
+        }
+      }
       kdSave();
     };
     list.appendChild(d);
@@ -9535,11 +9737,19 @@ function kdSetupPage() {
   });
   document.getElementById('kd-date-input').addEventListener('change', e => {
     const rec = kdRecords.find(r => r.id === kdActiveId);
-    if (rec) { rec.date = e.target.value; kdSave(); kdRenderTabs(); }
+    if (rec) { rec.date = e.target.value; kdSave(); kdRenderSidebar(); }
   });
   document.getElementById('kd-note-input').addEventListener('input', e => {
     const rec = kdRecords.find(r => r.id === kdActiveId);
     if (rec) { rec.note = e.target.value; kdSave(); }
+  });
+  document.getElementById('kd-backup-day').addEventListener('change', e => {
+    _kdBackupSchedule.day = parseInt(e.target.value);
+    kdSaveBackupSchedule(); kdUpdateBackupNextLabel();
+  });
+  document.getElementById('kd-backup-time').addEventListener('change', e => {
+    _kdBackupSchedule.time = e.target.value || '23:59';
+    kdSaveBackupSchedule(); kdUpdateBackupNextLabel();
   });
   document.getElementById('kd-link-close').addEventListener('click', () => {
     document.getElementById('kd-link-modal').classList.remove('open');
@@ -9549,6 +9759,9 @@ function kdSetupPage() {
     if (e.target.id === 'kd-link-modal') { document.getElementById('kd-link-modal').classList.remove('open'); kdRenderContent(); }
   });
   document.getElementById('kd-link-search').addEventListener('input', e => kdRenderLinkList(e.target.value));
+  // Auto-backup timer — checks every minute
+  if (_kdBackupTimer) clearInterval(_kdBackupTimer);
+  _kdBackupTimer = setInterval(kdRunAutoBackup, 60000);
 }
 
 function toggleHomePage(forceState) {
@@ -9985,6 +10198,10 @@ async function openProject(proj) {
     appState.tool         = s.tool         || 'select';
     appState.showGrid     = s.showGrid     || false;
     appState.zones3D      = s.zones3D      || [];
+    if (Array.isArray(s.kdRecords)) {
+      kdRecords = s.kdRecords;
+      try { localStorage.setItem(LS_KD_KEY(String(proj.id)), JSON.stringify(kdRecords)); } catch(e) {}
+    }
     annotIdCounter        = serverData.counter || 1;
     if (serverData.profese && Array.isArray(serverData.profese) && serverData.profese.length > 0) {
       appState.profese = serverData.profese;


### PR DESCRIPTION
- KD data (kdRecords) now included in _buildStateObj() and loaded from server in openProject — syncs via api/canvas.php
- kdSave() triggers _serverSave() so changes propagate to server
- New left sidebar replaces tab bar: records sorted by date (newest first), per-record delete, "+ Nový záznam" button
- Task fields extended: dateFrom and dateTo date pickers per task
- Auto-fill dates: linking task A to B copies B's dates to A when A has none
- Weekly auto-backup: configurable day + time in sidebar, fires via setInterval, stores last 12 backups in localStorage
- Backup next-run label shown in sidebar

https://claude.ai/code/session_012HVqboJ7mXP1ZqCRQNPMxc