### PR TITLE
Fix self-introduced bugs blocking Kontrolni den server saves

### DIFF
--- a/index.html
+++ b/index.html
@@ -9082,7 +9082,7 @@ async function _serverSaveNow() {
 async function _serverLoad(projectId) {
   try {
     const { ok, data } = await apiFetch(`api/canvas.php?project_id=${projectId}`);
-    if (ok && data.state && typeof data.state === 'object') {
+    if (ok && data.state !== null && data.state !== undefined && Array.isArray(data.state.levels)) {
       return data;
     }
   } catch(e) {}
@@ -9726,7 +9726,7 @@ function toggleKDPage() {
     kdCloseAllPops();
   } else {
     closeAnotacePage(); toggleHomePage(false); toggleUsersPage(false);
-    kdLoadBackupSchedule(); kdLoadCardWidth(); kdLoadZoom();
+    kdLoad(); kdLoadBackupSchedule(); kdLoadCardWidth(); kdLoadZoom();
     if (!kdActiveId && kdRecords.length) kdActiveId = kdRecords[kdRecords.length - 1].id;
     page.classList.add('visible'); btn.classList.add('active');
     _kdFilter = { sub: null, location: null, dateFrom: null, dateTo: null, urgent: false };
@@ -10554,8 +10554,8 @@ async function openProject(proj) {
   }
 
   currentProject = proj;
-  kdRecords = []; kdActiveId = null;  // reset – server data will populate below
-  _isProjectLoading = true;           // block any debounced saves during async server load
+  kdLoad(); kdActiveId = null;  // load from localStorage as initial value
+  _isProjectLoading = true;     // block debounced saves during async server load
   document.getElementById('project-screen').classList.add('hidden');
   updateTopbarUserInfo();
   applyViewerMode();
@@ -10580,11 +10580,15 @@ async function openProject(proj) {
     appState.tool         = s.tool         || 'select';
     appState.showGrid     = s.showGrid     || false;
     appState.zones3D      = s.zones3D      || [];
-    // Always set kdRecords from server (even if empty array) to prevent stale localStorage from winning
-    kdRecords = Array.isArray(s.kdRecords) ? s.kdRecords : [];
-    try { localStorage.setItem(LS_KD_KEY(String(proj.id)), JSON.stringify(kdRecords)); } catch(e) {}
-    kdLocations = Array.isArray(s.kdLocations) ? s.kdLocations : [];
-    try { localStorage.setItem(LS_KD_LOCATIONS_KEY(String(proj.id)), JSON.stringify(kdLocations)); } catch(e) {}
+    // Only overwrite from server when server actually has the data
+    if (Array.isArray(s.kdRecords)) {
+      kdRecords = s.kdRecords;
+      try { localStorage.setItem(LS_KD_KEY(String(proj.id)), JSON.stringify(kdRecords)); } catch(e) {}
+    }
+    if (Array.isArray(s.kdLocations)) {
+      kdLocations = s.kdLocations;
+      try { localStorage.setItem(LS_KD_LOCATIONS_KEY(String(proj.id)), JSON.stringify(kdLocations)); } catch(e) {}
+    }
     annotIdCounter        = serverData.counter || 1;
     if (serverData.profese && Array.isArray(serverData.profese) && serverData.profese.length > 0) {
       appState.profese = serverData.profese;
@@ -10593,9 +10597,7 @@ async function openProject(proj) {
     if (s.showGrid) { document.getElementById('grid-btn').classList.add('active'); drawGrid(); }
     setTool(window.innerWidth <= 768 ? 'pan' : appState.tool);
   } else {
-    loadState();  // fallback na localStorage (canvas data)
-    kdLoad();     // fallback na localStorage (KD data)
-    _isProjectLoading = false;
+    loadState(); // fallback na localStorage
   }
 
   if (appState.levels.length === 0) {


### PR DESCRIPTION
Previous fix introduced three regressions:

1. _serverLoad(): typeof null === 'object' is true in JS, so projects with no server state returned {state:null} instead of null. openProject() then crashed on null.levels → _isProjectLoading stuck at true forever → all _serverSave() calls silently blocked → KD data never reached the server. Fix: require data.state !== null && Array.isArray(data.state.levels)

2. openProject(): always assigning kdRecords from server even when server has no kdRecords field (kdRecords = [] default) overwrote valid localStorage data with empty array → data loss on first load after deploy if server state was saved before KD feature existed. Fix: reverted to conditional if (Array.isArray(s.kdRecords)) so localStorage keeps its value when server doesn't have the field.

3. toggleKDPage(): removed kdLoad() which is an intentional safety net — if openProject fails to populate kdRecords, opening the KD tab would still recover data from localStorage. Fix: restored kdLoad() call.

Also restored openProject() to use kdLoad() upfront (localStorage as initial value) then server overwrites if available — the intended flow.

https://claude.ai/code/session_01Epw3iDtL3kUNnhbHKaqqCM