### PR TITLE
Add dedicated KD endpoint - fix persistent save failure

### DIFF
--- a/api/kd.php
+++ b/api/kd.php
@@ -1,0 +1,98 @@
+<?php
+ob_start();
+ini_set('display_errors', 0);
+error_reporting(E_ALL);
+register_shutdown_function(function() {
+    $err = error_get_last();
+    if ($err && in_array($err['type'], [E_ERROR, E_CORE_ERROR, E_COMPILE_ERROR, E_PARSE, E_USER_ERROR])) {
+        ob_clean();
+        header('Content-Type: application/json');
+        http_response_code(500);
+        echo json_encode(['ok'=>false,'error'=>$err['message']]);
+    }
+});
+set_exception_handler(function($e) {
+    ob_clean();
+    header('Content-Type: application/json');
+    http_response_code(500);
+    echo json_encode(['ok'=>false,'error'=>$e->getMessage()]);
+    exit;
+});
+
+require_once __DIR__ . '/functions.php';
+
+$user      = requireAuth();
+$userId    = (int)$user['id'];
+$projectId = (int)($_GET['project_id'] ?? 0);
+$method    = $_SERVER['REQUEST_METHOD'];
+
+if (!$projectId) jsonError('Chybí project_id');
+
+$membership = getProjectMembership($projectId, $userId);
+if (!$membership) jsonError('Nemáš přístup k tomuto projektu', 403);
+
+// Vytvoř tabulku pokud neexistuje (idempotentní)
+getDB()->exec('CREATE TABLE IF NOT EXISTS plan_kd_data (
+    project_id INT          NOT NULL,
+    kd_json    MEDIUMTEXT,
+    updated_at TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (project_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci');
+
+// ============================================================
+// GET – načti KD záznamy
+// ============================================================
+if ($method === 'GET') {
+    $stmt = getDB()->prepare('SELECT kd_json, updated_at FROM plan_kd_data WHERE project_id = ? LIMIT 1');
+    $stmt->execute([$projectId]);
+    $row = $stmt->fetch();
+
+    if (!$row || !$row['kd_json']) {
+        jsonOk(['records' => [], 'updated_at' => null]);
+    }
+
+    $data = json_decode($row['kd_json'], true);
+    jsonOk([
+        'records'    => $data['records'] ?? [],
+        'updated_at' => $row['updated_at'],
+    ]);
+}
+
+// ============================================================
+// POST – ulož KD záznamy
+// Body: URL-encoded field "data" = JSON {records:[...]}
+// ============================================================
+if ($method === 'POST') {
+    if (!in_array($membership['role'], ['owner','admin','member'])) {
+        jsonError('Nemáš oprávnění upravovat záznamy', 403);
+    }
+
+    $rawJson = $_POST['data'] ?? '';
+    if (!$rawJson) $rawJson = file_get_contents('php://input');
+    if (!$rawJson) jsonError('Prázdné tělo požadavku', 400);
+
+    $body = json_decode($rawJson, true);
+    if ($body === null) jsonError('Neplatný JSON: ' . json_last_error_msg(), 400);
+
+    $records = $body['records'] ?? [];
+    if (!is_array($records)) jsonError('records musí být pole', 400);
+
+    $kdJson = json_encode(['records' => $records], JSON_UNESCAPED_UNICODE | JSON_PARTIAL_OUTPUT_ON_ERROR);
+    if ($kdJson === false || $kdJson === 'null') jsonError('Chyba serializace', 500);
+
+    $db = getDB();
+    $existing = $db->prepare('SELECT project_id FROM plan_kd_data WHERE project_id = ? LIMIT 1');
+    $existing->execute([$projectId]);
+
+    if ($existing->fetch()) {
+        $db->prepare('UPDATE plan_kd_data SET kd_json = ?, updated_at = NOW() WHERE project_id = ?')
+           ->execute([$kdJson, $projectId]);
+    } else {
+        $db->prepare('INSERT INTO plan_kd_data (project_id, kd_json) VALUES (?, ?)')
+           ->execute([$projectId, $kdJson]);
+    }
+
+    jsonOk(['saved' => true]);
+}
+
+jsonError('Metoda není povolena', 405);

--- a/index.html
+++ b/index.html
@@ -9600,7 +9600,32 @@ function openSearchPop(anchor, items, onSelect, placeholder) {
 function kdSave() {
   const pid = currentProject?.id; if (!pid) return;
   localStorage.setItem(LS_KD_KEY(pid), JSON.stringify(kdRecords));
-  _serverSave();
+  _serverSave();    // keep canvas state in sync
+  _kdDirectSave();  // dedicated KD endpoint – not blocked by _isProjectLoading
+}
+
+let _kdSaveTimer = null;
+function _kdDirectSave() {
+  clearTimeout(_kdSaveTimer);
+  _kdSaveTimer = setTimeout(async () => {
+    if (!currentProject) return;
+    try {
+      const formBody = 'data=' + encodeURIComponent(JSON.stringify({ records: kdRecords }));
+      await apiFetch(`api/kd.php?project_id=${currentProject.id}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: formBody,
+      });
+    } catch(e) { console.error('[kd] save error:', e); }
+  }, 1000);
+}
+
+async function _kdServerLoad(projectId) {
+  try {
+    const { ok, data } = await apiFetch(`api/kd.php?project_id=${projectId}`);
+    if (ok && Array.isArray(data.records)) return data.records;
+  } catch(e) {}
+  return null;
 }
 
 function kdSaveLocations() {
@@ -10570,8 +10595,13 @@ async function openProject(proj) {
   annotIdCounter = 1;
   undoStack = []; redoStack = [];
 
-  // Načti data ze serveru (primární) nebo z localStorage (záloha)
-  const serverData = await _serverLoad(proj.id);
+  // Načti canvas data ze serveru (primární) nebo z localStorage (záloha)
+  // Načti KD data z dedikovaného endpointu paralelně
+  const [serverData, kdServerRecords] = await Promise.all([
+    _serverLoad(proj.id),
+    _kdServerLoad(proj.id),
+  ]);
+
   if (serverData) {
     _lastKnownTs = serverData.updated_at || null;
     const s = serverData.state;
@@ -10580,11 +10610,6 @@ async function openProject(proj) {
     appState.tool         = s.tool         || 'select';
     appState.showGrid     = s.showGrid     || false;
     appState.zones3D      = s.zones3D      || [];
-    // Only overwrite from server when server actually has the data
-    if (Array.isArray(s.kdRecords)) {
-      kdRecords = s.kdRecords;
-      try { localStorage.setItem(LS_KD_KEY(String(proj.id)), JSON.stringify(kdRecords)); } catch(e) {}
-    }
     if (Array.isArray(s.kdLocations)) {
       kdLocations = s.kdLocations;
       try { localStorage.setItem(LS_KD_LOCATIONS_KEY(String(proj.id)), JSON.stringify(kdLocations)); } catch(e) {}
@@ -10599,6 +10624,18 @@ async function openProject(proj) {
   } else {
     loadState(); // fallback na localStorage
   }
+
+  // KD data: prefer dedicated endpoint > canvas state > localStorage
+  if (Array.isArray(kdServerRecords) && kdServerRecords.length > 0) {
+    kdRecords = kdServerRecords;
+    try { localStorage.setItem(LS_KD_KEY(String(proj.id)), JSON.stringify(kdRecords)); } catch(e) {}
+  } else if (serverData && Array.isArray(serverData.state?.kdRecords) && serverData.state.kdRecords.length > 0) {
+    // migrate: data was stored in canvas state – read it and save to dedicated endpoint
+    kdRecords = serverData.state.kdRecords;
+    try { localStorage.setItem(LS_KD_KEY(String(proj.id)), JSON.stringify(kdRecords)); } catch(e) {}
+    _kdDirectSave(); // persist to dedicated table
+  }
+  // else: kdLoad() at start already populated from localStorage
 
   if (appState.levels.length === 0) {
     addLevel('1.NP', '1.NP');
@@ -10967,6 +11004,16 @@ async function _pollLiveSync() {
     }
 
     if (changed) updateAnnotList();
+
+    // Sync KD records from dedicated endpoint (silent, no user prompt needed)
+    const remoteKd = await _kdServerLoad(currentProject.id);
+    if (Array.isArray(remoteKd) && remoteKd.length !== kdRecords.length) {
+      kdRecords = remoteKd;
+      try { localStorage.setItem(LS_KD_KEY(String(currentProject.id)), JSON.stringify(kdRecords)); } catch(e) {}
+      // Re-render KD panel if it's currently visible
+      const kdPage = document.getElementById('kd-page');
+      if (kdPage && kdPage.classList.contains('visible')) kdRenderPage();
+    }
 
   } catch(e) { /* network error – skip silently */ }
 }


### PR DESCRIPTION
Root cause: kdSave() relied on _serverSave() which is gated behind _isProjectLoading, _saving, and canEdit(). Any of these being true silently blocks the save with no retry, so KD changes never reached the server.

Solution: dedicated api/kd.php + plan_kd_data table that is completely independent of canvas state:

api/kd.php:
- GET ?project_id=X returns {records:[...]}
- POST saves records to plan_kd_data table (created on first call)
- No dependency on canvas state, profese, levels, or loading flags

JavaScript:
- kdSave() now calls _kdDirectSave() in addition to _serverSave()
- _kdDirectSave() posts directly to api/kd.php with 1s debounce, only checks currentProject (no _isProjectLoading gate)
- openProject() loads KD data from api/kd.php in parallel with canvas data; migrates old data from canvas state on first load
- _pollLiveSync() now syncs KD records to other users in real time

Data priority on load: kd.php > canvas state (migration) > localStorage

https://claude.ai/code/session_01Epw3iDtL3kUNnhbHKaqqCM