### PR TITLE
Fix crop: save to server + auto-reposition annotations

### DIFF
--- a/index.html
+++ b/index.html
@@ -4596,7 +4596,7 @@ async function loadImage(file, levelIdx) {
   });
 }
 
-function loadBackgroundImage(dataUrl, fit, onDone) {
+function loadBackgroundImage(dataUrl, fit, onDone, beforeSave) {
   fabric.Image.fromURL(dataUrl, (img) => {
     const level = appState.levels[appState.activeLevel];
     const cw = fabricCanvas.getWidth();
@@ -4628,6 +4628,7 @@ function loadBackgroundImage(dataUrl, fit, onDone) {
     fabricCanvas.renderAll();
     showDropZone(false);
     _isProjectLoading = false; // loading complete – saves are now allowed
+    if (beforeSave) beforeSave(img); // e.g. reposition annotations after crop
     saveCurrentLevel();
     if (onDone) onDone();
   });
@@ -4861,12 +4862,39 @@ async function confirmCrop() {
     img.src = srcUrl;
   });
 
+  // Capture old background params before replacing
+  const oldBgLeft = bgObj.left, oldBgTop = bgObj.top;
+  const oldBgSX   = bgObj.scaleX, oldBgSY = bgObj.scaleY;
+
   level.backgroundImage = croppedUrl;
   level.backgroundImageOriginal = croppedUrl;
   level.drawingAdjust = { brightness: 0, contrast: 0, grayscale: false };
   exitCropMode();
-  loadBackgroundImage(croppedUrl, true);
-  saveCurrentLevel();
+
+  // Load new background; beforeSave callback repositions all annotations
+  // then loadBackgroundImage calls saveCurrentLevel() once with correct state.
+  loadBackgroundImage(croppedUrl, true, null, (newBgImg) => {
+    const newBgLeft = newBgImg.left, newBgTop = newBgImg.top;
+    const newBgSX   = newBgImg.scaleX, newBgSY = newBgImg.scaleY;
+    const ratioX = newBgSX / oldBgSX;
+    const ratioY = newBgSY / oldBgSY;
+
+    fabricCanvas.getObjects().forEach(obj => {
+      if (obj.isBackground) return;
+      // Transform position: canvas → old-image → cropped-image → new canvas
+      const newLeft = (obj.left - oldBgLeft - cX * oldBgSX) * ratioX + newBgLeft;
+      const newTop  = (obj.top  - oldBgTop  - cY * oldBgSY) * ratioY + newBgTop;
+      obj.set({
+        left:   newLeft,
+        top:    newTop,
+        scaleX: obj.scaleX * ratioX,
+        scaleY: obj.scaleY * ratioY,
+      });
+      obj.setCoords();
+    });
+    fabricCanvas.renderAll();
+  });
+
   showToast('Výkres oříznut', 'success');
 }
 


### PR DESCRIPTION
Save fix:
- Removed premature saveCurrentLevel() from confirmCrop() (ran before loadBackgroundImage callback fired, capturing stale bg position)
- loadBackgroundImage now accepts optional beforeSave(newBgImg) callback called after new background is placed but before saveCurrentLevel(), so a single clean save captures correct bg position + transformed annotations

Annotation repositioning after crop:
- confirmCrop() captures old bg params (left, top, scaleX, scaleY) before crop
- Passes a beforeSave callback to loadBackgroundImage that:
    1. Gets new bg position/scale after fit-to-canvas placement
    2. Computes scale ratios (newBgScaleX / oldBgScaleX, same for Y)
    3. Transforms every non-background canvas object: left  = (obj.left - oldBgLeft - cX*oldBgSX) * ratioX + newBgLeft
       top   = (obj.top  - oldBgTop  - cY*oldBgSY) * ratioY + newBgTop
       scaleX = obj.scaleX * ratioX
       scaleY = obj.scaleY * ratioY
    4. Calls setCoords() + renderAll() so objects are interactable

https://claude.ai/code/session_01Epw3iDtL3kUNnhbHKaqqCM