### PR TITLE
Move docházkový list to first page; add supplier color dot

### DIFF
--- a/index.html
+++ b/index.html
@@ -8975,8 +8975,13 @@ function drawDochazkaPDF(pdf, rec, pdfLogo, PW, PH) {
     pdf.text(String(i + 1), COL_NR.x, tY);
     pdf.setFont('helvetica', 'normal');
 
-    // Firma
-    pdf.text(fitT(p.firma || p.name, ROW_FS, COL_FIRMA.w - 2), COL_FIRMA.x, tY);
+    // Color dot at start of Firma cell
+    pdf.setFillColor(r, g, b);
+    pdf.circle(COL_FIRMA.x + 1.5, rowY + ROW_H / 2, 1.3, 'F');
+
+    // Firma (offset right to clear dot)
+    pdf.setTextColor(40, 45, 35);
+    pdf.text(fitT(p.firma || p.name, ROW_FS, COL_FIRMA.w - 6), COL_FIRMA.x + 4, tY);
     // Role/profese
     pdf.setTextColor(100, 105, 90);
     pdf.text(fitT(p.name, ROW_FS, COL_ROLE.w - 2), COL_ROLE.x, tY);
@@ -9314,6 +9319,16 @@ async function doExportPDF() {
       return Math.max(m, anns.length);
     }, 0);
 
+    // ── Docházkový list (first page) ────────────────────────────
+    if (includeDochazka) {
+      const recForDoc = kdRecords.length > 0
+        ? [...kdRecords].sort((a,b) => (b.date||'') < (a.date||'') ? -1 : (b.date||'') > (a.date||'') ? 1 : 0)[0]
+        : { date: '', chapters: [] };
+      if (!first) pdf.addPage();
+      first = false;
+      drawDochazkaPDF(pdf, recForDoc, _pdfLogo, PW, PH);
+    }
+
     for (const idx of levelIdxs) {
       const level = appState.levels[idx];
       if (!level) continue;
@@ -9403,19 +9418,6 @@ async function doExportPDF() {
         if (!first) pdf.addPage();
         first = false;
         drawKDRecordToPDF(pdf, rec, _pdfLogo, PW, PH, inclHotovo);
-      }
-    }
-
-    // ── Docházkový list ─────────────────────────────────────────
-    if (includeDochazka) {
-      const kdRecsForDochazka = kdRecords.length > 0
-        ? [...kdRecords].sort((a,b) => (b.date||'') < (a.date||'') ? -1 : (b.date||'') > (a.date||'') ? 1 : 0)
-        : [{ date: '', chapters: [] }];
-      for (const rec of kdRecsForDochazka) {
-        if (!first) pdf.addPage();
-        first = false;
-        drawDochazkaPDF(pdf, rec, _pdfLogo, PW, PH);
-        break; // one attendance sheet is enough (profese list is global)
       }
     }
 


### PR DESCRIPTION
- Docházkový list is now the first page of the PDF export (before drawing/annotation/KD pages) when the checkbox is checked
- Each supplier row shows a filled color dot at the start of the Firma column matching the supplier's assigned color

https://claude.ai/code/session_01Epw3iDtL3kUNnhbHKaqqCM