### PR TITLE
migrate.php: diagnose inactive projects and missing creator memberships

### DIFF
--- a/api/migrate.php
+++ b/api/migrate.php
@@ -11,11 +11,7 @@ try {
     $appId = getPlansAppId();
     $result['plans_app_id'] = $appId;
 
-    // Count before
-    $result['plan_projects_before']         = (int)$db->query("SELECT COUNT(*) FROM plan_projects")->fetchColumn();
-    $result['plan_project_members_before']  = (int)$db->query("SELECT COUNT(*) FROM plan_project_members")->fetchColumn();
-
-    // Missing projects from board_projects
+    // ── 1. Copy missing projects from board_projects ──────────────────────
     $missing = $db->query(
         "SELECT bp.id FROM board_projects bp
          LEFT JOIN plan_projects pp ON pp.id = bp.id
@@ -24,38 +20,64 @@ try {
     $result['missing_project_ids'] = $missing;
 
     if (!empty($missing)) {
-        // Copy missing projects
-        $copied = $db->exec(
+        $ids = implode(',', array_map('intval', $missing));
+        $result['projects_copied'] = $db->exec(
             "INSERT IGNORE INTO plan_projects
                  (id, app_id, name, created_by, invite_code, is_active, created_at)
              SELECT id, app_id, name, created_by, invite_code, is_active, created_at
-             FROM board_projects
-             WHERE id IN (" . implode(',', array_map('intval', $missing)) . ")"
+             FROM board_projects WHERE id IN ($ids)"
         );
-        $result['projects_copied'] = $copied;
-
-        // Copy their members
-        $copied_members = $db->exec(
+        $result['members_copied'] = $db->exec(
             "INSERT IGNORE INTO plan_project_members
                  (id, project_id, user_id, role, invited_by, joined_at)
              SELECT bpm.id, bpm.project_id, bpm.user_id, bpm.role, bpm.invited_by, bpm.joined_at
-             FROM board_project_members bpm
-             WHERE bpm.project_id IN (" . implode(',', array_map('intval', $missing)) . ")"
+             FROM board_project_members bpm WHERE bpm.project_id IN ($ids)"
         );
-        $result['members_copied'] = $copied_members;
-    } else {
-        $result['projects_copied'] = 0;
-        $result['members_copied']  = 0;
-        $result['note'] = 'No missing projects found';
     }
 
-    // Count after
-    $result['plan_projects_after']        = (int)$db->query("SELECT COUNT(*) FROM plan_projects")->fetchColumn();
-    $result['plan_project_members_after'] = (int)$db->query("SELECT COUNT(*) FROM plan_project_members")->fetchColumn();
+    // ── 2. Soft-deleted projects (is_active = 0) ──────────────────────────
+    $result['inactive_projects'] = $db->query(
+        "SELECT id, app_id, name, created_by, is_active FROM plan_projects WHERE is_active = 0"
+    )->fetchAll();
 
-    // List all plan_projects now
-    $result['plan_projects_list'] = $db->query(
-        "SELECT id, app_id, name, created_by, is_active FROM plan_projects ORDER BY id DESC"
+    // ── 3. Fix: restore soft-deleted if ?restore=1 ────────────────────────
+    if (($_GET['restore'] ?? '') === '1') {
+        $restored = $db->exec("UPDATE plan_projects SET is_active = 1 WHERE is_active = 0");
+        $result['restored_count'] = $restored;
+    }
+
+    // ── 4. Projects where creator has no membership row ───────────────────
+    $result['creator_without_membership'] = $db->query(
+        "SELECT p.id, p.name, p.created_by, p.app_id
+         FROM plan_projects p
+         LEFT JOIN plan_project_members pm ON pm.project_id = p.id AND pm.user_id = p.created_by
+         WHERE pm.id IS NULL AND p.is_active = 1"
+    )->fetchAll();
+
+    // ── 5. Fix: add missing creator memberships if ?fix_members=1 ─────────
+    if (($_GET['fix_members'] ?? '') === '1') {
+        $orphans = $db->query(
+            "SELECT p.id, p.created_by FROM plan_projects p
+             LEFT JOIN plan_project_members pm ON pm.project_id = p.id AND pm.user_id = p.created_by
+             WHERE pm.id IS NULL AND p.is_active = 1"
+        )->fetchAll();
+        $added = 0;
+        foreach ($orphans as $o) {
+            $db->prepare(
+                "INSERT IGNORE INTO plan_project_members (project_id, user_id, role, invited_by) VALUES (?,?,'owner',?)"
+            )->execute([$o['id'], $o['created_by'], $o['created_by']]);
+            $added++;
+        }
+        $result['creator_memberships_added'] = $added;
+    }
+
+    // ── 6. Full project list ──────────────────────────────────────────────
+    $result['plan_projects_all'] = $db->query(
+        "SELECT p.id, p.app_id, p.name, p.created_by, p.is_active,
+                COUNT(pm.id) as member_count
+         FROM plan_projects p
+         LEFT JOIN plan_project_members pm ON pm.project_id = p.id
+         GROUP BY p.id ORDER BY p.id DESC"
     )->fetchAll();
 
     $result['ok'] = true;


### PR DESCRIPTION
Now shows: inactive (soft-deleted) projects, projects where creator has no membership row. Params: ?restore=1 reactivates deleted projects, ?fix_members=1 re-adds creator as owner where membership is missing.

https://claude.ai/code/session_01Epw3iDtL3kUNnhbHKaqqCM