### PR TITLE
Fix sticky section header in KD cards (desktop + mobile)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1541,6 +1541,7 @@ option { background: var(--card); color: var(--text); }
   border: 1px solid var(--border); border-radius: 8px;
   display: flex; flex-direction: column; flex-shrink: 0;
   max-height: calc(100vh - 160px); box-shadow: 0 1px 4px rgba(0,0,0,0.06);
+  overflow-y: auto;
 }
 .kd-card-header {
   display: flex; align-items: center; gap: 5px;
@@ -1567,7 +1568,7 @@ option { background: var(--card); color: var(--text); }
 }
 .kd-card-del-btn:hover { background: rgba(239,68,68,0.1); color: #EF4444; }
 .kd-tasks-list {
-  flex: 1; overflow-y: auto; padding: 5px 6px;
+  flex: 1; overflow-y: visible; padding: 5px 6px;
   display: flex; flex-direction: column; gap: 4px;
 }
 .kd-task {
@@ -2929,14 +2930,15 @@ th.sort-desc .sort-arrow::after { content: '▼'; opacity: 1; }
     flex: 0 0 calc(100% - 52px) !important;
     width: calc(100% - 52px) !important;
     min-width: 0 !important;
-    max-height: none !important;
+    max-height: 62vh !important;
     height: auto !important;
     scroll-snap-align: start;
     border-radius: 8px !important;
     border: 1px solid var(--border) !important;
     margin: 0 8px !important;
-    overflow-y: visible;
+    overflow-y: auto !important;
   }
+  /* Section header sticks to top of the card's own scroll viewport */
   .kd-card-header {
     position: sticky !important;
     top: 0 !important;


### PR DESCRIPTION
Root cause: .kd-tasks-list had overflow-y:auto, making it the scroll container, but .kd-card-header is its sibling (not inside it), so sticky had no scroll context. Also, zoom on #kd-cards-inner broke sticky for outer scroll container.

Fix: make .kd-card the scroll container (overflow-y:auto, max-height), .kd-tasks-list overflow-y:visible — card scrolls as a unit with the header sticky at top:0 relative to the card's own scroll viewport. Mobile: max-height:62vh so cards are bounded and scroll internally.

https://claude.ai/code/session_01Epw3iDtL3kUNnhbHKaqqCM