### PR TITLE
Fix annotation edits lost due to race condition with poll

### DIFF
--- a/index.html
+++ b/index.html
@@ -9871,8 +9871,12 @@ function _serverSave() {
 }
 let _saving = false;
 async function _serverSaveNow() {
-  _hasPendingSave = false;
-  if (!currentProject || _isProjectLoading || _saving || !canEdit()) return;
+  // Keep _hasPendingSave = true until save fully completes — prevents _pollLiveSync
+  // from overwriting appState with stale server data during in-flight network call.
+  if (!currentProject || _isProjectLoading || _saving || !canEdit()) {
+    _hasPendingSave = false; // bail-out path: safe to clear
+    return;
+  }
   _saving = true;
   // Capture active level canvas into appState before serialising
   if (fabricCanvas && appState.levels[appState.activeLevel]) {
@@ -9926,7 +9930,7 @@ async function _serverSaveNow() {
       }
     }
   } catch(e) { console.error('[canvas] save network error:', e); showToast('Chyba uložení: síťová chyba', 'error'); }
-  finally { _saving = false; }
+  finally { _saving = false; _hasPendingSave = false; }
 }
 
 // ---- Apply server-added objects (concurrent-save merge) ----


### PR DESCRIPTION
_hasPendingSave was cleared at the START of _serverSaveNow, but the actual network POST takes 200-500ms. During that window _pollLiveSync saw _hasPendingSave=false and overwrote appState.levels[i] with stale server data (pre-edit), discarding the annotation change locally.

Fix: move _hasPendingSave=false to the finally block, so it stays true for the entire save cycle (debounce + network round-trip). Poll skips inactive level merge until save fully completes.

https://claude.ai/code/session_01Epw3iDtL3kUNnhbHKaqqCM