### PR TITLE
Add sticky section-names bar below chapter header

### DIFF
--- a/index.html
+++ b/index.html
@@ -1676,6 +1676,29 @@ option { background: var(--card); color: var(--text); }
   /* Sticky works because zoom is applied to .kd-chapter-cards, not here */
   position: sticky; top: 0; z-index: 10;
 }
+/* Section-headers bar: zero-height sticky outside zoomed .kd-chapter-cards */
+.kd-card-headers-bar {
+  position: sticky; top: 40px; z-index: 9;
+  height: 0; overflow: visible;
+  margin-bottom: -8px; /* cancel flex gap so layout is unaffected */
+}
+.kd-card-headers-bar-inner {
+  display: none;
+  flex-direction: row; align-items: center; gap: 6px;
+  padding: 4px 14px;
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+  box-shadow: 0 3px 8px rgba(0,0,0,0.10);
+  overflow-x: auto; scrollbar-width: none;
+}
+.kd-card-headers-bar-inner::-webkit-scrollbar { display: none; }
+.kd-card-headers-bar.active .kd-card-headers-bar-inner { display: flex; }
+.kd-card-hdr-chip {
+  font-family: var(--font-mono); font-size: 11px; font-weight: 700;
+  color: var(--text-bright); background: var(--panel);
+  border: 1px solid var(--border); border-radius: 4px;
+  padding: 3px 10px; white-space: nowrap; flex-shrink: 0;
+}
 .kd-chapter-title-input {
   flex: 1; background: transparent; border: none; outline: none;
   font-family: var(--font-mono); font-size: 24px; font-weight: 700;
@@ -2919,6 +2942,8 @@ th.sort-desc .sort-arrow::after { content: '▼'; opacity: 1; }
   .kd-chapter-header { z-index: 6; }
   /* Force zoom=1 on cards row so .kd-card-header sticky works inside the card */
   .kd-chapter-cards { zoom: 1 !important; }
+  /* On mobile, each .kd-card is its own scroll viewport with sticky .kd-card-header */
+  .kd-card-headers-bar { display: none !important; }
   /* Cards row = horizontal snap carousel */
   .kd-chapter-cards {
     display: flex !important;
@@ -10987,6 +11012,26 @@ function kdApplyZoom() {
   document.querySelectorAll('#kd-cards-inner .kd-chapter-cards').forEach(el => {
     el.style.zoom = String(_kdZoom);
   });
+  _kdUpdateSectionBar();
+}
+
+function _kdUpdateSectionBar() {
+  const scroll = document.getElementById('kd-cards-scroll');
+  if (!scroll) return;
+  const scrollTop = scroll.getBoundingClientRect().top;
+  const CHAPTER_HDR_H = 42; // .kd-chapter-header is ~42px, sticks at top:0
+  document.querySelectorAll('#kd-cards-inner > .kd-chapter').forEach(ch => {
+    const bar = ch.querySelector(':scope > .kd-card-headers-bar');
+    const cardsRow = ch.querySelector(':scope > .kd-chapter-cards');
+    if (!bar || !cardsRow) return;
+    // Show bar when the top of the zoomed cards row is behind the sticky chapter header
+    const rowTop = cardsRow.getBoundingClientRect().top;
+    if (rowTop < scrollTop + CHAPTER_HDR_H) {
+      bar.classList.add('active');
+    } else {
+      bar.classList.remove('active');
+    }
+  });
 }
 
 function kdApplyCardWidth() {
@@ -11323,6 +11368,17 @@ function kdBuildChapter(rec, ch, isLive) {
   }
   el.appendChild(hdr);
 
+  // Sticky section-names bar (outside zoom — CSS sticky works here)
+  const hdrsBar = document.createElement('div'); hdrsBar.className = 'kd-card-headers-bar';
+  const hdrsBarInner = document.createElement('div'); hdrsBarInner.className = 'kd-card-headers-bar-inner';
+  (ch.cards || []).forEach(card => {
+    const chip = document.createElement('div'); chip.className = 'kd-card-hdr-chip';
+    chip.dataset.cardId = card.id; chip.textContent = card.title || 'Úsek';
+    hdrsBarInner.appendChild(chip);
+  });
+  hdrsBar.appendChild(hdrsBarInner);
+  el.appendChild(hdrsBar);
+
   const cardsRow = document.createElement('div'); cardsRow.className = 'kd-chapter-cards';
   (ch.cards || []).forEach(card => cardsRow.appendChild(kdBuildCard(rec, ch, card, isLive)));
 
@@ -11346,7 +11402,12 @@ function kdBuildCard(rec, ch, card, isLive) {
   const inp = document.createElement('input');
   inp.className = 'kd-card-title'; inp.value = card.title || '';
   inp.placeholder = 'Název úseku...'; inp.readOnly = !isLive;
-  inp.onchange = () => { card.title = inp.value; kdSave(); kdRenderSidebar(); };
+  inp.onchange = () => {
+    card.title = inp.value;
+    const chip = document.querySelector(`.kd-card-hdr-chip[data-card-id="${card.id}"]`);
+    if (chip) chip.textContent = inp.value || 'Úsek';
+    kdSave(); kdRenderSidebar();
+  };
   const cnt = document.createElement('span'); cnt.className = 'kd-card-count';
   hdr.appendChild(inp); hdr.appendChild(cnt);
   if (isLive) {
@@ -11716,6 +11777,7 @@ function kdSetupPage() {
     const ss = document.getElementById('kdf-sort-sub'); if (ss) ss.checked = false;
     kdRenderContent();
   });
+  document.getElementById('kd-cards-scroll').addEventListener('scroll', _kdUpdateSectionBar, { passive: true });
   // Ctrl+scroll to zoom the cards area
   document.getElementById('kd-cards-scroll').addEventListener('wheel', e => {
     if (!e.ctrlKey) return;


### PR DESCRIPTION
When scrolling causes .kd-chapter-cards (zoomed) to slip behind the sticky chapter title, a secondary sticky bar appears at top:40px showing the section names (Sekce E1, Sekce E2 …) as chips.

- .kd-card-headers-bar: height:0 / overflow:visible sticky element inside .kd-chapter but OUTSIDE .kd-chapter-cards zoom — CSS sticky works here without any zoom ancestor
- _kdUpdateSectionBar(): scroll listener checks getBoundingClientRect on the cards row; activates bar when row top < scroll container top
  + chapter header height (~42px)
- Chip text synced when card title input changes
- Hidden on mobile (each .kd-card already has sticky .kd-card-header)

https://claude.ai/code/session_01Epw3iDtL3kUNnhbHKaqqCM