### PR TITLE
KD: fix section bar z-index so ::after doesn't cover it in subsequent…

### DIFF
--- a/index.html
+++ b/index.html
@@ -1687,7 +1687,7 @@ option { background: var(--card); color: var(--text); }
 }
 /* Section-headers bar: zero-height sticky outside zoomed .kd-chapter-cards */
 .kd-card-headers-bar {
-  position: sticky; top: 40px; z-index: 9;
+  position: sticky; top: 40px; z-index: 10;
   height: 0; overflow: visible;
   margin-bottom: -8px; /* cancel flex gap so layout is unaffected */
 }


### PR DESCRIPTION
… chapters

Raise .kd-card-headers-bar from z-index:9 to z-index:10 so it paints above chapter header ::after extensions (which live in a z-index:10 stacking context). Same z-index → document order determines winner, so each chapter's section bar correctly paints on top of prior chapters' background extensions.

https://claude.ai/code/session_01Epw3iDtL3kUNnhbHKaqqCM