### PR TITLE
Docházkový list: solid color Nr cell, remove dot circles

### DIFF
--- a/index.html
+++ b/index.html
@@ -9280,24 +9280,20 @@ function drawDochazkaPDF(pdf, rec, pdfLogo, PW, PH) {
     pdf.setFillColor(Math.round(r * 0.15 + 255 * 0.85), Math.round(g * 0.15 + 255 * 0.85), Math.round(b * 0.15 + 255 * 0.85));
     pdf.rect(lx, rowY, lw, ROW_H, 'F');
 
-    // Full-color left accent stripe
+    // Full-color Nr cell background
     pdf.setFillColor(r, g, b);
-    pdf.rect(lx, rowY, 1.8, ROW_H, 'F');
+    pdf.rect(lx, rowY, COL_FIRMA.x - lx, ROW_H, 'F');
 
     pdf.setFont('helvetica', 'normal'); pdf.setFontSize(ROW_FS); pdf.setTextColor(40, 45, 35);
     const midY = rowY + ROW_H * 0.62;
 
-    // Nr
-    pdf.setFont('helvetica', 'bold');
+    // Nr – white text on colored cell
+    pdf.setFont('helvetica', 'bold'); pdf.setTextColor(255, 255, 255);
     pdf.text(String(i + 1), COL_NR.x, midY);
-    pdf.setFont('helvetica', 'normal');
+    pdf.setFont('helvetica', 'normal'); pdf.setTextColor(40, 45, 35);
 
-    // Color dot + Firma
-    pdf.setFillColor(r, g, b);
-    const dotR = Math.min(1.3, ROW_H * 0.16);
-    pdf.circle(COL_FIRMA.x + dotR + 0.5, rowY + ROW_H / 2, dotR, 'F');
-    pdf.setTextColor(40, 45, 35);
-    pdf.text(fitT(p.firma || p.name, ROW_FS, COL_FIRMA.w - 6), COL_FIRMA.x + 4, midY);
+    // Firma (no dot)
+    pdf.text(fitT(p.firma || p.name, ROW_FS, COL_FIRMA.w - 2), COL_FIRMA.x + 1, midY);
 
     // Role / Kontakt / Telefon
     pdf.setTextColor(100, 105, 90);


### PR DESCRIPTION
- Replace thin 1.8mm accent stripe with full-width colored Nr column cell
- Nr number text is now white (legible on any contractor color)
- Remove colored dot circles before the firm name
- Firma text shifted left to fill freed space

https://claude.ai/code/session_01Epw3iDtL3kUNnhbHKaqqCM