### PR TITLE
Fix section header not covering full row in narrow window

### DIFF
--- a/index.html
+++ b/index.html
@@ -1699,6 +1699,7 @@ option { background: var(--card); color: var(--text); }
   border-bottom: 1px solid var(--border);
   box-shadow: 0 3px 8px rgba(0,0,0,0.10);
   position: relative; overflow: visible;
+  min-width: 100vw;
 }
 .kd-card-headers-bar-inner::after {
   content: '';


### PR DESCRIPTION
The chips inner element could be narrower than the viewport when there are few card columns, leaving a gap between the chips and the right viewport edge. The ::after (position:absolute) was clipped by the overflow-x:auto scroll container and could not fill the gap.

Fix: min-width:100vw on .kd-card-headers-bar-inner ensures the element always fills at least the full viewport width, so its background color covers the entire row regardless of chip count or window size.

https://claude.ai/code/session_01Epw3iDtL3kUNnhbHKaqqCM