### PR TITLE
Sync annotation edits to active level in live poll

### DIFF
--- a/index.html
+++ b/index.html
@@ -12905,6 +12905,40 @@ async function _pollLiveSync() {
         _applyServerAdded([{ levelId: remActive.id, objects: serverOnlyObjs }]);
         changed = true;
       }
+
+      // Sync edits to existing annotations on active level
+      if (!_hasPendingSave && fabricCanvas) {
+        const remObjMap = new Map();
+        (remActive.fabricJSON?.objects || [])
+          .filter(o => o.annotId && !o.isBackground && !o.annotLabelFor)
+          .forEach(o => remObjMap.set(o.annotId, o));
+        const annotKey = o => [o.profese,o.popisek,o.priorita,o.status,o.prirazeno,o.deadline,o.dateFrom].join('\x00');
+        let activeEdited = false;
+        fabricCanvas.getObjects()
+          .filter(o => o.annotId && !o.isBackground && !o.annotLabelFor && remObjMap.has(o.annotId))
+          .forEach(locObj => {
+            const remObj = remObjMap.get(locObj.annotId);
+            if (annotKey(remObj) === annotKey(locObj)) return;
+            locObj.set({
+              profese:   remObj.profese   ?? locObj.profese,
+              popisek:   remObj.popisek   ?? locObj.popisek,
+              priorita:  remObj.priorita  ?? locObj.priorita,
+              status:    remObj.status    ?? locObj.status,
+              prirazeno: remObj.prirazeno ?? locObj.prirazeno,
+              deadline:  remObj.deadline  ?? locObj.deadline,
+              dateFrom:  remObj.dateFrom  ?? locObj.dateFrom,
+            });
+            applyAnnotColorToCanvas(locObj);
+            updateLabelFor(locObj.annotId);
+            activeEdited = true;
+          });
+        if (activeEdited) {
+          fabricCanvas.renderAll();
+          saveCurrentLevel();
+          changed = true;
+        }
+      }
+
       // Show badge when background was replaced (crop) or annotation count differs (deletions/edits)
       if (bgChanged) {
         _syncPending = true;


### PR DESCRIPTION
New annotations were already propagated, but edits to existing ones (text, supplier, status, priority, deadline) were silently ignored on the active level because _pollLiveSync only merged objects absent from the local set.

Now compares key annotation fields (profese/popisek/priorita/status/ prirazeno/deadline/dateFrom) for every annotId present in both local canvas and server data; when they differ (and no local save is pending) it patches the fabric object in place, re-applies colour, updates the label, and re-renders — without touching position or shape.

https://claude.ai/code/session_01Epw3iDtL3kUNnhbHKaqqCM