### PR TITLE
Fix: home/anotace/users pages hidden behind level-bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -1927,7 +1927,7 @@ option { background: var(--card); color: var(--text); }
 .kdf-active { border-color: var(--olive) !important; color: var(--olive) !important; }
 #anotace-page {
   display: none; position: fixed;
-  top: 48px; left: 0; right: 0; bottom: 26px;
+  top: 88px; left: 0; right: 0; bottom: 26px;
   z-index: 50;
   background: var(--bg); flex-direction: column; overflow: hidden;
 }
@@ -1989,7 +1989,7 @@ option { background: var(--card); color: var(--text); }
 /* HOME PAGE OVERLAY */
 #home-page {
   position: fixed;
-  top: 48px;
+  top: 88px;
   left: 0; right: 0;
   bottom: 26px;
   background: var(--bg);
@@ -2668,7 +2668,7 @@ th.sort-desc .sort-arrow::after { content: '▼'; opacity: 1; }
 /* ---- Members panel ---- */
 #users-page {
   position: fixed;
-  top: 48px; left: 0; right: 0; bottom: 26px;
+  top: 88px; left: 0; right: 0; bottom: 26px;
   background: var(--bg);
   z-index: 50;
   display: none;


### PR DESCRIPTION
#level-bar is a flex item with z-index:99, which per CSS spec creates a stacking context — it paints above #home-page/#anotace-page/#users-page (z-index:50 each) even though they are fixed-positioned.

Move their top from 48px to 88px (48 topbar + 40 level-bar) so content starts below the floor-tabs bar and is fully visible. #kd-page already has z-index:102 so it correctly overlaps the bar.

https://claude.ai/code/session_01Epw3iDtL3kUNnhbHKaqqCM