### PR TITLE
Fix: profese changes lost when canvas auto-save was in-flight

### DIFF
--- a/api/canvas.php
+++ b/api/canvas.php
@@ -140,7 +140,7 @@ if ($method === 'POST') {
     try {
         // Zamkni řádek – atomická operace (SELECT FOR UPDATE)
         $stmt = $db->prepare(
-            'SELECT state_json, annot_counter FROM plan_canvas_data WHERE project_id = ? FOR UPDATE'
+            'SELECT state_json, profese_json, annot_counter FROM plan_canvas_data WHERE project_id = ? FOR UPDATE'
         );
         $stmt->execute([$projectId]);
         $existingRow = $stmt->fetch();
@@ -148,10 +148,14 @@ if ($method === 'POST') {
         // Načti server stav pro merge
         $serverLevels  = [];
         $serverCounter = 1;
+        $serverProfese = [];
         if ($existingRow && $existingRow['state_json']) {
             $serverState  = json_decode(_decompress($existingRow['state_json']), true);
             $serverLevels = $serverState['levels'] ?? [];
             $serverCounter = (int)($existingRow['annot_counter'] ?? 1);
+        }
+        if ($existingRow && $existingRow['profese_json']) {
+            $serverProfese = json_decode(_decompress($existingRow['profese_json']), true) ?? [];
         }
 
         // Merge každého levelu – zachová anotace přidané jiným uživatelem
@@ -218,9 +222,18 @@ if ($method === 'POST') {
             jsonError('Chyba serializace stavu: ' . json_last_error_msg(), 500);
         }
 
-        $profeseJson = null;
+        // Merge profese: client wins per name, server-only entries preserved.
+        // Prevents a stale client from silently deleting profese added by another user.
+        $mergedProfese = null;
         if ($profese !== null) {
-            $profeseJson = json_encode($profese, JSON_UNESCAPED_UNICODE | JSON_PARTIAL_OUTPUT_ON_ERROR);
+            $mergedProfese = _mergeProfese($serverProfese, $profese);
+        } elseif (!empty($serverProfese)) {
+            $mergedProfese = $serverProfese; // client sent nothing – keep server data
+        }
+
+        $profeseJson = null;
+        if ($mergedProfese !== null) {
+            $profeseJson = json_encode($mergedProfese, JSON_UNESCAPED_UNICODE | JSON_PARTIAL_OUTPUT_ON_ERROR);
             if ($profeseJson === false) $profeseJson = null;
         }
 
@@ -263,6 +276,24 @@ if ($method === 'POST') {
 // server-only items jsou zachovány (přidal jiný uživatel)
 // Returns: [mergedArray, serverOnlyItems]
 // ============================================================
+// Merge profese arrays: client version wins per name (last-write-wins),
+// server-only entries (added by another user) are appended so they are never lost.
+function _mergeProfese(array $server, array $client): array {
+    $clientByName = [];
+    foreach ($client as $p) {
+        $name = $p['name'] ?? null;
+        if ($name !== null) $clientByName[$name] = $p;
+    }
+    $merged = $client; // start with all client entries (client wins for matching names)
+    foreach ($server as $p) {
+        $name = $p['name'] ?? null;
+        if ($name !== null && !isset($clientByName[$name])) {
+            $merged[] = $p; // server-only entry – preserve it
+        }
+    }
+    return $merged;
+}
+
 function _mergeCanvasObjects(array $serverObjs, array $clientObjs): array {
     $clientIds = [];
     foreach ($clientObjs as $o) {

--- a/index.html
+++ b/index.html
@@ -10423,9 +10423,16 @@ let _saving = false;
 async function _serverSaveNow() {
   // Keep _hasPendingSave = true until save fully completes — prevents _pollLiveSync
   // from overwriting appState with stale server data during in-flight network call.
-  if (!currentProject || _isProjectLoading || _saving || !canEdit()) {
-    _hasPendingSave = false; // bail-out path: safe to clear
+  if (!currentProject || _isProjectLoading || !canEdit()) {
+    _hasPendingSave = false; // bail-out: no project / loading / read-only
     return;
+  }
+  if (_saving) {
+    // A save is already in-flight and was serialised before this call —
+    // schedule a retry so the latest state (e.g. profese edits) is not lost.
+    clearTimeout(_srvTimer);
+    _srvTimer = setTimeout(_serverSaveNow, 1000);
+    return; // _hasPendingSave stays true until the retry completes
   }
   _saving = true;
   // Capture active level canvas into appState before serialising


### PR DESCRIPTION
_serverSaveNow() checked all bail conditions together and cleared _hasPendingSave before returning — including when _saving=true (a save already in-flight). That save was serialised before the profese edit, so new profese never reached the server and was permanently dropped.

Separate the _saving guard: instead of bailing silently, schedule a 1 s retry so _serverSaveNow runs again after the in-flight save finishes and picks up the latest appState.profese.

https://claude.ai/code/session_01Epw3iDtL3kUNnhbHKaqqCM