### PR TITLE
Fix stale data overwriting: server-authoritative open, PHP field prot…

### DIFF
--- a/api/canvas.php
+++ b/api/canvas.php
@@ -295,14 +295,32 @@ function _mergeProfese(array $server, array $client): array {
 }
 
 function _mergeCanvasObjects(array $serverObjs, array $clientObjs): array {
+    // Build server map for quick lookup by annotId
+    $serverMap = [];
+    foreach ($serverObjs as $o) {
+        $aid = $o['annotId'] ?? null;
+        if ($aid) $serverMap[$aid] = $o;
+    }
     $clientIds = [];
     foreach ($clientObjs as $o) {
         $aid = $o['annotId'] ?? null;
         if ($aid) $clientIds[$aid] = true;
     }
 
-    $merged     = $clientObjs;
+    $merged = [];
     $serverOnly = [];
+    foreach ($clientObjs as $o) {
+        $aid = $o['annotId'] ?? null;
+        if ($aid && isset($serverMap[$aid])) {
+            // Preserve server's non-empty text fields when client sends empty —
+            // prevents a stale device (same account) from wiping another device's work.
+            $srv = $serverMap[$aid];
+            foreach (['popisek', 'prirazeno'] as $tf) {
+                if (empty($o[$tf]) && !empty($srv[$tf])) $o[$tf] = $srv[$tf];
+            }
+        }
+        $merged[] = $o;
+    }
     foreach ($serverObjs as $o) {
         $aid = $o['annotId'] ?? null;
         if ($aid && !isset($clientIds[$aid])) {
@@ -314,14 +332,29 @@ function _mergeCanvasObjects(array $serverObjs, array $clientObjs): array {
 }
 
 function _mergeCanvasAnnotations(array $serverAnnots, array $clientAnnots): array {
+    $serverMap = [];
+    foreach ($serverAnnots as $a) {
+        $aid = $a['annotId'] ?? null;
+        if ($aid) $serverMap[$aid] = $a;
+    }
     $clientIds = [];
     foreach ($clientAnnots as $a) {
         $aid = $a['annotId'] ?? null;
         if ($aid) $clientIds[$aid] = true;
     }
 
-    $merged     = $clientAnnots;
+    $merged = [];
     $serverOnly = [];
+    foreach ($clientAnnots as $a) {
+        $aid = $a['annotId'] ?? null;
+        if ($aid && isset($serverMap[$aid])) {
+            $srv = $serverMap[$aid];
+            foreach (['popisek', 'prirazeno'] as $tf) {
+                if (empty($a[$tf]) && !empty($srv[$tf])) $a[$tf] = $srv[$tf];
+            }
+        }
+        $merged[] = $a;
+    }
     foreach ($serverAnnots as $a) {
         $aid = $a['annotId'] ?? null;
         if ($aid && !isset($clientIds[$aid])) {

--- a/index.html
+++ b/index.html
@@ -10584,11 +10584,23 @@ function _applyServerAdded(serverAdded) {
       fabric.util.enlivenObjects(toAdd, (enlivened) => {
         enlivened.forEach(obj => {
           fabricCanvas.add(obj);
-          if (obj.annotId) createAnnotLabel(obj); // create label for newly synced annotation
+          if (obj.annotId) createAnnotLabel(obj);
+          // Update appState.annotations directly — do NOT call saveCurrentLevel() here.
+          // A re-save would send our current canvas state (possibly stale for other fields
+          // like popisek) back to the server, overwriting a co-worker's fresh data.
+          const lvl = appState.levels[levelIdx];
+          if (lvl && obj.annotId) {
+            lvl.annotations = lvl.annotations || [];
+            lvl.annotations.push({
+              annotId: obj.annotId, profese: obj.profese || null, popisek: obj.popisek || null,
+              priorita: obj.priorita || null, prirazeno: obj.prirazeno || null,
+              status: obj.status || null, createdAt: obj.createdAt || null,
+              deadline: obj.deadline || null, dateFrom: obj.dateFrom || null
+            });
+          }
         });
         deconflictLabels();
         fabricCanvas.renderAll();
-        saveCurrentLevel(); // update appState.levels[active] from canvas
         updateAnnotList();
       });
     } else {
@@ -12601,18 +12613,54 @@ async function openProject(proj) {
 
   if (serverData) {
     _lastKnownTs = serverData.updated_at || null;
-    // If localStorage has unsaved changes (dirty flag set before server confirmed them),
-    // prefer localStorage so edits made just before a reload are not lost.
     const _pid = String(proj.id);
     const _lsDirty = localStorage.getItem(LS_PROJECT_DIRTY(_pid)) === '1';
     if (_lsDirty) {
+      // Load localStorage to capture any annotations added locally but not yet saved to server
+      // (e.g. tab was closed before the 2s debounce fired, or network was down).
       loadState();
+      const _localLevels = (appState.levels || []).map(l => ({
+        id: l.id,
+        annotations: (l.annotations || []).slice(),
+        fabricObjs: new Map((l.fabricJSON?.objects || []).map(o => [o.annotId, o]))
+      }));
+
+      // Use server state as the authoritative base — server is newest when another device
+      // has been saving. Prevents stale localStorage from overwriting a co-worker's work.
+      const s = serverData.state;
+      appState.levels      = s.levels       || [];
+      appState.activeLevel = s.activeLevel  || 0;
+      appState.tool        = s.tool         || 'select';
+      appState.showGrid    = s.showGrid     || false;
+      appState.zones3D     = s.zones3D      || [];
+      if (Array.isArray(s.kdLocations)) {
+        kdLocations = s.kdLocations;
+        try { localStorage.setItem(LS_KD_LOCATIONS_KEY(_pid), JSON.stringify(kdLocations)); } catch(e) {}
+      }
       annotIdCounter = Math.max(annotIdCounter, serverData.counter || 1);
-      // Always prefer server profese — supplier config is shared and server is authoritative
       if (serverData.profese && Array.isArray(serverData.profese) && serverData.profese.length > 0) {
         appState.profese = serverData.profese;
       }
-      // Push the local state to the server immediately to close the gap
+
+      // Re-add any annotations that were created locally but are absent from server
+      // (the only thing that could be lost if server is taken as base).
+      _localLevels.forEach(loc => {
+        const srv = appState.levels.find(l => l.id === loc.id);
+        if (!srv) return;
+        const srvIds = new Set((srv.annotations || []).map(a => a.annotId));
+        loc.annotations.forEach(a => {
+          if (!a.annotId || srvIds.has(a.annotId)) return;
+          srv.annotations = srv.annotations || [];
+          srv.annotations.push(a);
+          if (srv.fabricJSON) {
+            srv.fabricJSON.objects = srv.fabricJSON.objects || [];
+            const fo = loc.fabricObjs.get(a.annotId);
+            if (fo) srv.fabricJSON.objects.push(fo);
+          }
+        });
+      });
+
+      // Push merged state (server base + local-only additions) to server
       setTimeout(() => { if (!_isProjectLoading) { clearTimeout(_srvTimer); _serverSaveNow(); } }, 800);
     } else {
       const s = serverData.state;


### PR DESCRIPTION
…ection, no re-save

openProject() dirty path:
- Was: loadState() (stale localStorage) + auto-save → overwrites another device's work
- Now: use server state as base, then re-add only annotations that exist locally but are absent from server (locally created, not yet confirmed on server). This way server data (from another tab/device) is never overwritten on project open.

_applyServerAdded():
- Removed saveCurrentLevel() from the enlivenObjects callback. This was triggering an immediate re-save with whatever was locally in the canvas — if the local canvas had stale popisek for other annotations, that stale data would overwrite the server's fresh values. Now only appState.annotations is updated in-memory; the next user-initiated save will capture the correct state from canvas.

canvas.php _mergeCanvasObjects / _mergeCanvasAnnotations:
- Added server-map lookup for matching annotIds
- For text fields (popisek, prirazeno): preserve server's non-empty value when client sends empty — last line of defense against a stale device erasing text that another device correctly filled in

https://claude.ai/code/session_01Epw3iDtL3kUNnhbHKaqqCM