### PR TITLE
Fix popisek sync revert on level switch

### DIFF
--- a/index.html
+++ b/index.html
@@ -13132,10 +13132,11 @@ async function _pollLiveSync() {
           });
         if (activeEdited) {
           fabricCanvas.renderAll();
-          // Update appState annotations in-memory without triggering a server re-save.
-          // The remote edits were already saved by the other user; re-saving would create
-          // an unnecessary round-trip and reset _lastOwnSaveTs, delaying future syncs.
-          appState.levels[appState.activeLevel].annotations = fabricCanvas.getObjects()
+          // Snapshot canvas into fabricJSON so level-switch reloads the synced values.
+          // Without this, switchLevel() reloads from stale fabricJSON and reverts popisek.
+          const _snap = _canvasJSON();
+          appState.levels[appState.activeLevel].fabricJSON = _snap;
+          appState.levels[appState.activeLevel].annotations = _snap.objects
             .filter(o => o.annotId && !o.isBackground && !o.annotLabelFor)
             .map(o => ({ annotId: o.annotId, profese: o.profese, popisek: o.popisek,
               priorita: o.priorita, prirazeno: o.prirazeno, status: o.status,


### PR DESCRIPTION
Annotation-edit sync was updating canvas objects and appState.annotations but not appState.levels[activeLevel].fabricJSON. When the user switched levels and returned, switchLevel() reloaded the canvas from the stale fabricJSON, reverting any popisek values synced from another device.

Fix: after syncing, snapshot the canvas with _canvasJSON() and write the result into both fabricJSON and annotations so level switches preserve the synced state.

https://claude.ai/code/session_01Epw3iDtL3kUNnhbHKaqqCM