### PR TITLE
Add per-annotation updatedAt timestamps to resolve popisek sync confl…

### DIFF
--- a/api/canvas.php
+++ b/api/canvas.php
@@ -312,12 +312,22 @@ function _mergeCanvasObjects(array $serverObjs, array $clientObjs): array {
     foreach ($clientObjs as $o) {
         $aid = $o['annotId'] ?? null;
         if ($aid && isset($serverMap[$aid])) {
-            // Preserve server's non-empty text fields when client sends empty —
-            // prevents a stale device (same account) from wiping another device's work.
             $srv = $serverMap[$aid];
-            foreach (['popisek', 'prirazeno'] as $tf) {
-                if (empty($o[$tf]) && !empty($srv[$tf])) $o[$tf] = $srv[$tf];
+            $clientTs = (int)($o['updatedAt']  ?? 0);
+            $serverTs = (int)($srv['updatedAt'] ?? 0);
+            if ($serverTs > $clientTs) {
+                // Server annotation is newer — use server's field values
+                foreach (['popisek', 'prirazeno', 'profese', 'priorita', 'status', 'deadline', 'dateFrom'] as $tf) {
+                    $o[$tf] = $srv[$tf] ?? $o[$tf];
+                }
+                $o['updatedAt'] = $serverTs;
+            } elseif ($clientTs === 0 && $serverTs === 0) {
+                // Legacy (no timestamps): preserve server non-empty text fields
+                foreach (['popisek', 'prirazeno'] as $tf) {
+                    if (empty($o[$tf]) && !empty($srv[$tf])) $o[$tf] = $srv[$tf];
+                }
             }
+            // clientTs >= serverTs and at least one has timestamp: client is newer, keep as-is
         }
         $merged[] = $o;
     }
@@ -349,8 +359,17 @@ function _mergeCanvasAnnotations(array $serverAnnots, array $clientAnnots): arra
         $aid = $a['annotId'] ?? null;
         if ($aid && isset($serverMap[$aid])) {
             $srv = $serverMap[$aid];
-            foreach (['popisek', 'prirazeno'] as $tf) {
-                if (empty($a[$tf]) && !empty($srv[$tf])) $a[$tf] = $srv[$tf];
+            $clientTs = (int)($a['updatedAt']  ?? 0);
+            $serverTs = (int)($srv['updatedAt'] ?? 0);
+            if ($serverTs > $clientTs) {
+                foreach (['popisek', 'prirazeno', 'profese', 'priorita', 'status', 'deadline', 'dateFrom'] as $tf) {
+                    $a[$tf] = $srv[$tf] ?? $a[$tf];
+                }
+                $a['updatedAt'] = $serverTs;
+            } elseif ($clientTs === 0 && $serverTs === 0) {
+                foreach (['popisek', 'prirazeno'] as $tf) {
+                    if (empty($a[$tf]) && !empty($srv[$tf])) $a[$tf] = $srv[$tf];
+                }
             }
         }
         $merged[] = $a;

--- a/index.html
+++ b/index.html
@@ -5751,13 +5751,13 @@ function addAnnotationProperties(obj, type) {
     prirazeno: '',
     status: 'Nový úkol',
     createdAt: new Date().toISOString(),
+    updatedAt: Date.now(),
     lockMovementX: true, lockMovementY: true,
     lockScalingX: true,  lockScalingY: true,
     lockRotation: true,
     hasControls: false,
     hasBorders: true,
-    perPixelTargetFind: true,
-    createdAt: new Date().toISOString()
+    perPixelTargetFind: true
   });
   return obj;
 }
@@ -6864,6 +6864,7 @@ function updateActiveAnnotProp(prop, value) {
   if (!obj || obj.isBackground) return;
 
   obj.set(prop, value);
+  obj.updatedAt = Date.now();
 
   // Update annotation label
   if (prop === 'profese' || prop === 'popisek' || prop === 'deadline' || prop === 'dateFrom') {
@@ -7135,7 +7136,7 @@ function drawGrid() {
 // ============================================================
 // UNDO / REDO
 // ============================================================
-const _JSON_FIELDS = ['annotId','profese','popisek','priorita','prirazeno','status','annotType','annotLabelFor','createdAt','deadline','dateFrom','isBackground','isPolyHelper'];
+const _JSON_FIELDS = ['annotId','profese','popisek','priorita','prirazeno','status','annotType','annotLabelFor','createdAt','updatedAt','deadline','dateFrom','isBackground','isPolyHelper'];
 
 function _canvasJSON() {
   const json = fabricCanvas.toJSON(_JSON_FIELDS);
@@ -7188,7 +7189,7 @@ function copySelected() {
   obj.clone((cloned) => {
     appState.clipboard = cloned;
     showToast('Zkopírováno', 'info');
-  }, ['annotId','profese','popisek','priorita','prirazeno','status','annotType','annotLabelFor','createdAt','deadline','dateFrom']);
+  }, ['annotId','profese','popisek','priorita','prirazeno','status','annotType','annotLabelFor','createdAt','updatedAt','deadline','dateFrom']);
 }
 
 function pasteSelected() {
@@ -7202,7 +7203,7 @@ function pasteSelected() {
     updateAnnotList();
     saveCurrentLevel();
     clearTimeout(_srvTimer); _serverSaveNow();
-  }, ['annotId','profese','popisek','priorita','prirazeno','status','annotType','annotLabelFor','createdAt','deadline','dateFrom']);
+  }, ['annotId','profese','popisek','priorita','prirazeno','status','annotType','annotLabelFor','createdAt','updatedAt','deadline','dateFrom']);
 }
 
 // ============================================================
@@ -10316,8 +10317,8 @@ function saveCurrentLevel() {
   appState.levels[appState.activeLevel].annotations = annotObjects.map(o => ({
     annotId: o.annotId, profese: o.profese, popisek: o.popisek,
     priorita: o.priorita, prirazeno: o.prirazeno, status: o.status,
-    createdAt: o.createdAt || null, deadline: o.deadline || null,
-    dateFrom: o.dateFrom || null
+    createdAt: o.createdAt || null, updatedAt: o.updatedAt || null,
+    deadline: o.deadline || null, dateFrom: o.dateFrom || null
   }));
 
   saveState();
@@ -10510,14 +10511,15 @@ async function _serverSaveNow() {
   _saving = true;
   // Capture active level canvas into appState before serialising
   if (fabricCanvas && appState.levels[appState.activeLevel]) {
-    const _snap = fabricCanvas.toJSON(['annotId','profese','popisek','priorita','prirazeno','status','annotType','annotLabelFor','createdAt','deadline','dateFrom','isBackground']);
+    const _snap = fabricCanvas.toJSON(['annotId','profese','popisek','priorita','prirazeno','status','annotType','annotLabelFor','createdAt','updatedAt','deadline','dateFrom','isBackground']);
     _snap.objects = (_snap.objects || []).filter(o => o.name !== '__background__' && !o.isBackground && !o.annotLabelFor);
     appState.levels[appState.activeLevel].fabricJSON = _snap;
     // refresh annotations list for this level
     appState.levels[appState.activeLevel].annotations = _snap.objects.filter(o => o.annotId).map(o => ({
       annotId: o.annotId, profese: o.profese, popisek: o.popisek,
       priorita: o.priorita, prirazeno: o.prirazeno, status: o.status,
-      createdAt: o.createdAt || null, deadline: o.deadline || null, dateFrom: o.dateFrom || null
+      createdAt: o.createdAt || null, updatedAt: o.updatedAt || null,
+      deadline: o.deadline || null, dateFrom: o.dateFrom || null
     }));
   }
   try {
@@ -10595,6 +10597,7 @@ function _applyServerAdded(serverAdded) {
               annotId: obj.annotId, profese: obj.profese || null, popisek: obj.popisek || null,
               priorita: obj.priorita || null, prirazeno: obj.prirazeno || null,
               status: obj.status || null, createdAt: obj.createdAt || null,
+              updatedAt: obj.updatedAt || null,
               deadline: obj.deadline || null, dateFrom: obj.dateFrom || null
             });
           }
@@ -10617,6 +10620,7 @@ function _applyServerAdded(serverAdded) {
           annotId: o.annotId, profese: o.profese || null, popisek: o.popisek || null,
           priorita: o.priorita || null, prirazeno: o.prirazeno || null,
           status: o.status || null, createdAt: o.createdAt || null,
+          updatedAt: o.updatedAt || null,
           deadline: o.deadline || null, dateFrom: o.dateFrom || null
         });
         existingIds.add(o.annotId);
@@ -13115,15 +13119,19 @@ async function _pollLiveSync() {
           .forEach(locObj => {
             const remObj = remObjMap.get(locObj.annotId);
             if (annotKey(remObj) === annotKey(locObj)) return;
+            // Skip if local edit is newer (same account, different device typing concurrently)
+            const remTs = remObj.updatedAt || 0;
+            const locTs = locObj.updatedAt || 0;
+            if (locTs > remTs) return;
             locObj.set({
               profese:   remObj.profese   ?? locObj.profese,
-              // Use || for text fields: empty string from server must not wipe local typed value
               popisek:   remObj.popisek   || locObj.popisek,
               priorita:  remObj.priorita  ?? locObj.priorita,
               status:    remObj.status    ?? locObj.status,
               prirazeno: remObj.prirazeno || locObj.prirazeno,
               deadline:  remObj.deadline  ?? locObj.deadline,
               dateFrom:  remObj.dateFrom  ?? locObj.dateFrom,
+              updatedAt: remObj.updatedAt ?? locObj.updatedAt,
             });
             applyAnnotColorToCanvas(locObj);
             updateLabelFor(locObj.annotId);
@@ -13140,7 +13148,8 @@ async function _pollLiveSync() {
             .filter(o => o.annotId && !o.isBackground && !o.annotLabelFor)
             .map(o => ({ annotId: o.annotId, profese: o.profese, popisek: o.popisek,
               priorita: o.priorita, prirazeno: o.prirazeno, status: o.status,
-              createdAt: o.createdAt || null, deadline: o.deadline || null, dateFrom: o.dateFrom || null }));
+              createdAt: o.createdAt || null, updatedAt: o.updatedAt || null,
+              deadline: o.deadline || null, dateFrom: o.dateFrom || null }));
           changed = true;
           // Refresh right panel if the currently selected annotation was among those updated
           if (selectedUpdated && selObj) onObjectSelected({ target: selObj });


### PR DESCRIPTION
…icts

Without timestamps, PHP merge always applied client values for non-empty fields, so whichever device saved last permanently overwrote the other's popisek — causing the persistent divergence visible in the screenshot.

Changes:
- Stamp updatedAt = Date.now() on annotation creation and on every updateActiveAnnotProp() call, so each edit carries a precise timestamp
- Include updatedAt in _JSON_FIELDS and all toJSON/clone calls so the timestamp travels with the annotation through fabricJSON and to the server
- PHP merge: if server's updatedAt > client's, server's field values win; if client's >= server's, client wins; if neither has a timestamp, fall back to the previous empty-field-preservation behaviour (no regression)
- Client annotation-edit sync: skip applying remote popisek when local updatedAt is strictly newer (local user typed more recently)

This makes the system a true last-write-wins CRDT per annotation, so the most recently edited device's popisek always propagates correctly.

https://claude.ai/code/session_01Epw3iDtL3kUNnhbHKaqqCM