### PR TITLE
Fix KD sync kick-out, mobile add-button layout, and new-task scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -3021,7 +3021,7 @@ th.sort-desc .sort-arrow::after { content: '▼'; opacity: 1; }
     background: var(--panel) !important;
     border-radius: 8px 8px 0 0 !important;
   }
-  .kd-tasks-list { overflow-y: visible !important; max-height: none !important; }
+  .kd-tasks-list { overflow-y: visible !important; max-height: none !important; flex: 0 0 auto !important; }
   /* Hide add-card button inside snap row (use add-chapter-btn-main instead) */
   .kd-add-card-btn { display: none !important; }
   .kd-add-chapter-btn-main { display: none !important; }
@@ -11293,11 +11293,12 @@ function kdSave() {
   _kdDirectSave();  // dedicated KD endpoint – not blocked by _isProjectLoading
 }
 
-let _kdSaveTimer   = null;
-let _kdLastKdTs    = null;   // KD-specific updated_at from server
-let _kdSavePending = false;  // true while a save is in-flight (blocks merge to protect deletions)
-let _kdDirty       = false;  // true from first local edit until save completes
+let _kdSaveTimer     = null;
+let _kdLastKdTs      = null;   // KD-specific updated_at from server
+let _kdSavePending   = false;  // true while a save is in-flight (blocks merge to protect deletions)
+let _kdDirty         = false;  // true from first local edit until save completes
 let _kdPendingRender = false;  // deferred re-render while user types
+let _kdLastOwnSaveTs = 0;      // timestamp of last successful own save (ms)
 
 function _kdDirectSave() {
   clearTimeout(_kdSaveTimer);
@@ -11314,7 +11315,7 @@ function _kdDirectSave() {
       // Don't merge response — client already has the correct post-deletion state.
       // Merging here would undo local deletions (server still has old data until this save).
       // Concurrent additions from other users are handled by _pollKDSync.
-      if (ok) { _kdLastKdTs = null; _kdDirty = false; } // force next poll to fetch fresh server state
+      if (ok) { _kdLastKdTs = null; _kdDirty = false; _kdLastOwnSaveTs = Date.now(); } // force next poll to fetch fresh server state
     } catch(e) { console.error('[kd] save error:', e); }
     finally { _kdSavePending = false; }
   }, 1000);
@@ -11340,6 +11341,8 @@ function _kdMergeFromServer(serverRecords) {
   });
   // Full replace when user has no unsaved local edits (pure viewer — sync everything)
   if (!_kdDirty) {
+    const newJson = JSON.stringify(serverRecords);
+    if (newJson === JSON.stringify(kdRecords)) return false; // identical — no re-render needed
     kdRecords = serverRecords;
     return true;
   }
@@ -12031,10 +12034,14 @@ function kdAddCard(rec, ch) {
 function kdAddTask(rec, card) {
   const task = { id: kdGenId(), text: '', sub: null, dateFrom: null, dateTo: null, locations: [], urgent: false, done: false, writtenAt: Date.now() };
   card.tasks.push(task); kdSave(); kdRenderContent();
-  requestAnimationFrame(() => requestAnimationFrame(() => {
+  // On mobile, keyboard popup shifts the viewport — wait 350 ms so it settles before centering
+  const scrollDelay = /Mobi|Android|iPhone|iPad/i.test(navigator.userAgent) ? 350 : 0;
+  setTimeout(() => {
     const el = document.querySelector(`.kd-task[data-task-id="${task.id}"] .kd-task-text`);
-    if (el) { el.scrollIntoView({ behavior: 'smooth', block: 'center' }); el.focus(); }
-  }));
+    if (!el) return;
+    el.focus();
+    requestAnimationFrame(() => el.scrollIntoView({ behavior: 'smooth', block: 'center' }));
+  }, scrollDelay);
 }
 
 // ── Chapter helpers ──────────────────────────────────────────────
@@ -13270,8 +13277,11 @@ async function _pollKDSync() {
     if (!kdResult) return;
 
     _kdLastKdTs = kdResult.updatedAt;
+    // Skip re-render for 3s after our own save — the poll would otherwise see our own
+    // data and trigger a kdRenderPage() that kicks the user out of whatever they're editing.
+    const ownSaveRecent = (Date.now() - _kdLastOwnSaveTs) < 3000;
     const mergeChanged = _kdMergeFromServer(kdResult.records);
-    if (mergeChanged) {
+    if (mergeChanged && !ownSaveRecent) {
       try { localStorage.setItem(LS_KD_KEY(String(currentProject.id)), JSON.stringify(kdRecords)); } catch(e) {}
       const kdPage = document.getElementById('kd-page');
       if (kdPage && kdPage.classList.contains('visible') && !_kdViewingBackup) {


### PR DESCRIPTION
- Mobile: add `flex: 0 0 auto` to .kd-tasks-list so it no longer stretches over the "+ Přidat úkol" button on small screens
- Mobile: delay scrollIntoView after kdAddTask by 350 ms so the virtual keyboard has time to open before centering the new task
- KD sync: track _kdLastOwnSaveTs after each successful save and suppress re-render for 3 s — prevents the poll from kicking the user out of a textarea immediately after their own save completes
- KD sync: _kdMergeFromServer now compares JSON before full-replace and returns false when data is identical, avoiding unnecessary kdRenderPage() calls for unchanged server state

https://claude.ai/code/session_01Epw3iDtL3kUNnhbHKaqqCM