### PR TITLE
Redesign pin annotation to Google Maps style, half the original size

### DIFF
--- a/index.html
+++ b/index.html
@@ -3509,7 +3509,7 @@ th.sort-desc .sort-arrow::after { content: '▼'; opacity: 1; }
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="9" width="20" height="6" rx="1" stroke="currentColor" stroke-width="2" fill="currentColor" fill-opacity="0.35"/><line x1="7" y1="9" x2="7" y2="15" stroke="currentColor" stroke-width="1.5"/><line x1="12" y1="9" x2="12" y2="15" stroke="currentColor" stroke-width="1.5"/><line x1="17" y1="9" x2="17" y2="15" stroke="currentColor" stroke-width="1.5"/></svg>
     </button>
     <button class="tb-btn tool-btn" id="tool-pin" data-tool="pin" title="Špendlík (P)">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2a5 5 0 0 1 5 5c0 3.5-5 11-5 11S7 10.5 7 7a5 5 0 0 1 5-5z"/><circle cx="12" cy="7" r="1.5" fill="currentColor"/></svg>
+      <svg viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
     </button>
     <button class="tb-btn tool-btn" id="tool-text" data-tool="text" title="Text (T)">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 7V4h16v3M9 20h6M12 4v16"/></svg>
@@ -3599,7 +3599,7 @@ th.sort-desc .sort-arrow::after { content: '▼'; opacity: 1; }
     <button class="tb-btn tool-btn mob-tool" data-tool="circle" title="Kruh"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/></svg></button>
     <button class="tb-btn tool-btn mob-tool" data-tool="arrow" title="Šipka"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg></button>
     <button class="tb-btn tool-btn mob-tool" data-tool="partition" title="Příčka"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="9" width="20" height="6" rx="1" stroke="currentColor" stroke-width="2" fill="currentColor" fill-opacity="0.35"/><line x1="7" y1="9" x2="7" y2="15" stroke="currentColor" stroke-width="1.5"/><line x1="12" y1="9" x2="12" y2="15" stroke="currentColor" stroke-width="1.5"/><line x1="17" y1="9" x2="17" y2="15" stroke="currentColor" stroke-width="1.5"/></svg></button>
-    <button class="tb-btn tool-btn mob-tool" data-tool="pin" title="Špendlík"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2a5 5 0 0 1 5 5c0 3.5-5 11-5 11S7 10.5 7 7a5 5 0 0 1 5-5z"/><circle cx="12" cy="7" r="1.5" fill="currentColor"/></svg></button>
+    <button class="tb-btn tool-btn mob-tool" data-tool="pin" title="Špendlík"><svg viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg></button>
     <button class="tb-btn tool-btn mob-tool" data-tool="text" title="Text"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 7V4h16v3M9 20h6M12 4v16"/></svg></button>
     <div class="tb-separator"></div>
     <button class="tb-btn mob-tool" onclick="document.getElementById('zoom-in-btn').click()" title="Přiblížit"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/><line x1="11" y1="8" x2="11" y2="14"/><line x1="8" y1="11" x2="14" y2="11"/></svg></button>
@@ -3900,7 +3900,7 @@ th.sort-desc .sort-arrow::after { content: '▼'; opacity: 1; }
       Příčka
     </button>
     <button class="mob-draw-tool tool-btn" data-tool="pin" onclick="setTool('pin');closeMobDrawMenu()">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="20" height="20"><path d="M12 2a5 5 0 0 1 5 5c0 3.5-5 11-5 11S7 10.5 7 7a5 5 0 0 1 5-5z"/><circle cx="12" cy="7" r="1.5" fill="currentColor"/></svg>
+      <svg viewBox="0 0 24 24" fill="currentColor" stroke="none" width="20" height="20"><path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
       Špendlík
     </button>
     <button class="mob-draw-tool tool-btn" data-tool="text" onclick="setTool('text');closeMobDrawMenu()">
@@ -4376,7 +4376,7 @@ function applyAnnotColorToCanvas(obj) {
   } else if (obj.type === 'ellipse' || obj.type === 'polygon') {
     obj.set({ stroke: color, fill: color + '22' });
   } else if (obj.type === 'path' && obj.annotType === 'pin') {
-    obj.set({ stroke: color, fill: color + '22' });
+    obj.set({ stroke: color, fill: color, fillRule: 'evenodd' });
   } else if (obj.type === 'path' || obj.type === 'polyline') {
     obj.set({ stroke: color, fill: 'transparent' });
   } else if (obj.type === 'i-text' || obj.type === 'text') {
@@ -6839,13 +6839,17 @@ function onKeyUp(e) { /* handled in main listener */ }
 // ============================================================
 function placePinAt(x, y) {
   const color = getActiveProfeseColor();
-  // Teardrop pointing down: tip at (0,0), circle head above centered at (0,-18) r=12
-  const d = 'M 0 0 C -11 -4 -12 -11 -12 -18 A 12 12 0 1 1 12 -18 C 12 -11 11 -4 0 0 Z';
+  // Google Maps-style pin: tip at (0,0), circle head (r=6) centered at (0,-9).
+  // Tangent lines from tip meet the circle at (±4, -4.5). Total height 15, width 12.
+  // Inner circle (r=2.5) creates a transparent hole via evenodd fill rule.
+  const d = 'M 0 0 C -2 -1.5 -4 -3 -4 -4.5 A 6 6 0 1 1 4 -4.5 C 4 -3 2 -1.5 0 0 Z ' +
+            'M 2.5 -9 A 2.5 2.5 0 1 0 -2.5 -9 A 2.5 2.5 0 1 0 2.5 -9 Z';
   const pin = new fabric.Path(d, {
     left: x, top: y,
     originX: 'center', originY: 'bottom',
-    fill: color + '22',
-    stroke: color, strokeWidth: 2, strokeUniform: true,
+    fill: color,
+    fillRule: 'evenodd',
+    stroke: color, strokeWidth: 1.5, strokeUniform: true,
     selectable: true,
   });
   addAnnotationProperties(pin, 'pin');


### PR DESCRIPTION
- New canvas path: tip at (0,0), circle head r=6 centered at (0,-9), smooth bezier "legs" tapering to the tip — total height 15 px (was 30). Inner circle subpath r=2.5 at the head center creates a transparent hole via evenodd fill rule, giving the classic Google Maps look.
- Fill changed from semi-transparent (color+'22') to solid color with evenodd fill rule; applyAnnotColorToCanvas updated to match.
- All three toolbar/draw-menu SVG icons updated to the Material Design location_on path (same Google Maps teardrop + center hole).

https://claude.ai/code/session_01Epw3iDtL3kUNnhbHKaqqCM