### PR TITLE
Fix KD date row, sticky section headers, and user management layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -2728,15 +2728,22 @@ th.sort-desc .sort-arrow::after { content: '▼'; opacity: 1; }
 .members-invite-row select { padding: 8px 10px; background: var(--card); border: 1px solid var(--border); border-radius: 5px; color: var(--text); font-size: 13px; }
 .members-invite-row button { padding: 8px 16px; background: var(--olive); border: none; border-radius: 5px; color: #fff; font-size: 13px; font-weight: 600; cursor: pointer; }
 .members-invite-row button:hover { background: var(--olive-hover); }
-.member-row { display: flex; align-items: center; gap: 10px; padding: 10px 0; border-bottom: 1px solid var(--border); }
+.member-row { display: flex; align-items: center; gap: 10px; padding: 10px 0; border-bottom: 1px solid var(--border); flex-wrap: wrap; }
 .member-avatar { width: 32px; height: 32px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 13px; font-weight: 700; color: #fff; flex-shrink: 0; }
 .member-info { flex: 1; min-width: 0; }
-.member-name { font-size: 13px; font-weight: 600; color: var(--text-bright); }
-.member-email { font-size: 11px; color: var(--text-dim); }
-.member-role-select { padding: 4px 8px; background: var(--card); border: 1px solid var(--border); border-radius: 4px; color: var(--text); font-size: 12px; }
-.member-remove-btn { background: none; border: none; color: var(--text-dim); cursor: pointer; font-size: 16px; padding: 4px 6px; border-radius: 4px; }
+.member-name { font-size: 13px; font-weight: 600; color: var(--text-bright); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.member-email { font-size: 11px; color: var(--text-dim); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.member-role-select { padding: 4px 8px; background: var(--card); border: 1px solid var(--border); border-radius: 4px; color: var(--text); font-size: 12px; flex-shrink: 0; }
+.member-remove-btn { background: none; border: none; color: var(--text-dim); cursor: pointer; font-size: 16px; padding: 4px 6px; border-radius: 4px; flex-shrink: 0; }
 .member-remove-btn:hover { background: rgba(239,68,68,0.15); color: #EF4444; }
-.member-role-badge { padding: 2px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; }
+.member-role-badge { padding: 2px 8px; border-radius: 10px; font-size: 11px; font-weight: 600; flex-shrink: 0; }
+/* Mobile: profese select wraps to its own row below name/avatar */
+.member-profese-wrap { display: contents; }
+@media (max-width: 768px) {
+  .member-profese-select { min-width: 0 !important; width: 100%; }
+  .member-profese-wrap { display: flex; flex: 0 0 100%; padding-left: 42px; box-sizing: border-box; }
+  .member-profese-wrap .member-profese-select { flex: 1; }
+}
 .role-owner { background: rgba(245,158,11,0.2); color: #F59E0B; }
 .role-admin { background: rgba(139,92,246,0.2); color: #8B5CF6; }
 .role-member { background: rgba(59,130,246,0.2); color: #3B82F6; }
@@ -12172,7 +12179,7 @@ function kdRenderContent() {
     return;
   }
 
-  if (meta) meta.style.display  = 'flex';
+  if (meta) meta.style.display = (window.innerWidth > 768) ? 'flex' : 'none';
   if (fbar) fbar.style.display = 'flex';
   const mobBar = document.getElementById('kd-mobile-bottom-bar');
   if (mobBar) mobBar.style.display = 'flex';
@@ -12237,6 +12244,12 @@ function kdRenderContent() {
   }
   scroll.appendChild(inner);
   kdApplyZoom();
+  // On mobile: force overflow:visible so CSS sticky works on .kd-card-header
+  if (window.innerWidth <= 768) {
+    inner.querySelectorAll('.kd-chapter-cards, .kd-card').forEach(el => {
+      el.style.overflow = 'visible';
+    });
+  }
   scroll.scrollTop = savedScrollTop;
 }
 
@@ -12899,11 +12912,6 @@ async function loadMembers() {
         <div class="member-name">${escHtml(m.name)}</div>
         <div class="member-email">${escHtml(m.email)}</div>
       </div>
-      <select class="member-profese-select" onchange="setMemberProfese(${m.user_id},this.value)" title="Přiřadit k subdodavateli"
-        style="${profColor ? `border-left:3px solid ${escHtml(profColor)}` : ''}">
-        <option value="">— subdodavatel —</option>
-        ${profeseOpts}
-      </select>
       ${canEdit
         ? `<select class="member-role-select" onchange="changeMemberRole(${m.id},this.value)">
             ${['admin','member','viewer'].map(r=>`<option value="${r}"${r===m.role?' selected':''}>${roleLabels[r]}</option>`).join('')}
@@ -12911,6 +12919,13 @@ async function loadMembers() {
            <button class="member-remove-btn" onclick="removeMember(${m.id})" title="Odebrat">×</button>`
         : `<span class="member-role-badge role-${m.role}">${roleLabels[m.role]||m.role}</span>`
       }
+      <div class="member-profese-wrap">
+        <select class="member-profese-select" onchange="setMemberProfese(${m.user_id},this.value)" title="Přiřadit k subdodavateli"
+          style="${profColor ? `border-left:3px solid ${escHtml(profColor)}` : ''}">
+          <option value="">— subdodavatel —</option>
+          ${profeseOpts}
+        </select>
+      </div>
     </div>`;
   }).join('');
 


### PR DESCRIPTION
- KD meta-bar: use JS width check (not just CSS) to never show on mobile; CSS !important vs JS inline style is unreliable on some mobile browsers
- Sticky section headers: after rendering, explicitly set overflow:visible via JS on .kd-chapter-cards and .kd-card so CSS sticky escapes to the outer scroll container (#kd-cards-scroll)
- User management: profese select wraps to its own row below name/avatar on mobile via .member-profese-wrap; role select + remove button stay on the same line as the name

https://claude.ai/code/session_01Epw3iDtL3kUNnhbHKaqqCM