### PR TITLE
Separate profese into dedicated plan_profese table for independent sync

### DIFF
--- a/api/profese.php
+++ b/api/profese.php
@@ -1,0 +1,255 @@
+<?php
+ob_start();
+ini_set('display_errors', 0);
+error_reporting(E_ALL);
+register_shutdown_function(function() {
+    $err = error_get_last();
+    if ($err && in_array($err['type'], [E_ERROR, E_CORE_ERROR, E_COMPILE_ERROR, E_PARSE, E_USER_ERROR])) {
+        ob_clean();
+        header('Content-Type: application/json');
+        http_response_code(500);
+        echo json_encode(['ok'=>false,'error'=>$err['message'],'file'=>basename($err['file']),'line'=>$err['line']]);
+    }
+});
+set_exception_handler(function($e) {
+    ob_clean();
+    header('Content-Type: application/json');
+    http_response_code(500);
+    echo json_encode(['ok'=>false,'error'=>$e->getMessage(),'file'=>basename($e->getFile()),'line'=>$e->getLine()]);
+    exit;
+});
+
+require_once __DIR__ . '/functions.php';
+
+$user      = requireAuth();
+$userId    = (int)$user['id'];
+$projectId = (int)($_GET['project_id'] ?? 0);
+$method    = $_SERVER['REQUEST_METHOD'];
+
+if (!$projectId) jsonError('Chybí project_id');
+$membership = getProjectMembership($projectId, $userId);
+if (!$membership) jsonError('Nemáš přístup k tomuto projektu', 403);
+
+getDB()->exec('CREATE TABLE IF NOT EXISTS plan_profese (
+    id            INT AUTO_INCREMENT PRIMARY KEY,
+    project_id    INT          NOT NULL,
+    name          VARCHAR(255) NOT NULL,
+    firma         VARCHAR(255) DEFAULT NULL,
+    emails_json   TEXT         DEFAULT NULL,
+    kontakt       VARCHAR(255) DEFAULT NULL,
+    telefon       VARCHAR(100) DEFAULT NULL,
+    color         VARCHAR(32)  DEFAULT NULL,
+    export_pinned TINYINT(1)   NOT NULL DEFAULT 0,
+    sort_order    INT          NOT NULL DEFAULT 0,
+    updated_at    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_proj_name (project_id, name),
+    INDEX idx_project (project_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci');
+
+// ── GET ────────────────────────────────────────────────────────
+if ($method === 'GET') {
+    if (!empty($_GET['ts_only'])) {
+        $stmt = getDB()->prepare('SELECT MAX(updated_at) AS updated_at FROM plan_profese WHERE project_id = ?');
+        $stmt->execute([$projectId]);
+        $row = $stmt->fetch();
+        jsonOk(['updated_at' => $row['updated_at'] ?? null]);
+    }
+    $rows = _profLoad($projectId);
+    jsonOk(['profese' => _rowsToProfese($rows)]);
+}
+
+// ── POST ───────────────────────────────────────────────────────
+if ($method === 'POST') {
+    if (!in_array($membership['role'], ['owner','admin','member'])) {
+        jsonError('Nemáš oprávnění upravovat profesí', 403);
+    }
+    $rawJson = $_POST['data'] ?? '';
+    if (!$rawJson) $rawJson = file_get_contents('php://input');
+    if (!$rawJson) jsonError('Prázdné tělo požadavku', 400);
+
+    $body = json_decode($rawJson, true);
+    if ($body === null) jsonError('Neplatný JSON: ' . json_last_error_msg(), 400);
+
+    $incoming = $body['profese'] ?? null;
+    $deleted  = $body['deleted']  ?? [];
+    if (!is_array($incoming)) jsonError('profese musí být pole', 400);
+    if (!is_array($deleted))  $deleted = [];
+
+    $db = getDB();
+    $db->beginTransaction();
+    try {
+        $stmt = $db->prepare(
+            'SELECT name, firma, emails_json, kontakt, telefon, color, export_pinned, sort_order
+               FROM plan_profese WHERE project_id = ? FOR UPDATE ORDER BY sort_order, name'
+        );
+        $stmt->execute([$projectId]);
+        $existing = $stmt->fetchAll();
+
+        $existingByName = [];
+        foreach ($existing as $e) $existingByName[$e['name']] = $e;
+
+        // Explicit deletions (user clicked "Smazat")
+        if (!empty($deleted)) {
+            $ph = implode(',', array_fill(0, count($deleted), '?'));
+            $db->prepare("DELETE FROM plan_profese WHERE project_id = ? AND name IN ($ph)")
+               ->execute(array_merge([$projectId], $deleted));
+            foreach ($deleted as $dn) unset($existingByName[$dn]);
+        }
+
+        $incomingByName = [];
+        foreach ($incoming as $p) {
+            $n = $p['name'] ?? null;
+            if ($n !== null) $incomingByName[$n] = $p;
+        }
+
+        // Merge: client entries + server-only entries not explicitly deleted
+        $toUpsert = $incoming;
+        foreach ($existingByName as $name => $e) {
+            if (!isset($incomingByName[$name])) {
+                $toUpsert[] = [
+                    'name'         => $e['name'],
+                    'firma'        => $e['firma'],
+                    '_emails_json' => $e['emails_json'], // already encoded
+                    'kontakt'      => $e['kontakt'],
+                    'telefon'      => $e['telefon'],
+                    'color'        => $e['color'],
+                    'exportPinned' => (bool)$e['export_pinned'],
+                ];
+            }
+        }
+
+        $ins = $db->prepare(
+            'INSERT INTO plan_profese
+                 (project_id, name, firma, emails_json, kontakt, telefon, color, export_pinned, sort_order)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+             ON DUPLICATE KEY UPDATE
+               firma=VALUES(firma), emails_json=VALUES(emails_json), kontakt=VALUES(kontakt),
+               telefon=VALUES(telefon), color=VALUES(color), export_pinned=VALUES(export_pinned),
+               sort_order=VALUES(sort_order), updated_at=NOW()'
+        );
+
+        foreach ($toUpsert as $i => $p) {
+            $name = $p['name'] ?? null;
+            if (!$name) continue;
+            if (isset($p['_emails_json'])) {
+                $emailsJson = $p['_emails_json'];
+            } elseif (isset($p['emails']) && is_array($p['emails'])) {
+                $emailsJson = json_encode(array_values(array_filter($p['emails'])));
+            } elseif (isset($p['email'])) {
+                $emailsJson = is_array($p['email'])
+                    ? json_encode(array_values(array_filter($p['email'])))
+                    : json_encode(array_filter([$p['email']]));
+            } else {
+                $emailsJson = null;
+            }
+            $ins->execute([
+                $projectId, $name,
+                $p['firma']   ?? null,
+                $emailsJson,
+                $p['kontakt'] ?? null,
+                $p['telefon'] ?? null,
+                $p['color']   ?? null,
+                !empty($p['exportPinned']) ? 1 : 0,
+                $i,
+            ]);
+        }
+
+        $db->commit();
+        $rows = _profLoad($projectId);
+        jsonOk(['profese' => _rowsToProfese($rows)]);
+    } catch (Exception $e) {
+        $db->rollBack();
+        jsonError('Chyba při ukládání profesí: ' . $e->getMessage(), 500);
+    }
+}
+
+jsonError('Metoda není povolena', 405);
+
+// ── Helpers ───────────────────────────────────────────────────
+
+function _profLoad(int $projectId): array {
+    $db   = getDB();
+    $stmt = $db->prepare(
+        'SELECT name, firma, emails_json, kontakt, telefon, color, export_pinned, sort_order
+           FROM plan_profese WHERE project_id = ? ORDER BY sort_order, name'
+    );
+    $stmt->execute([$projectId]);
+    $rows = $stmt->fetchAll();
+    if (!empty($rows)) return $rows;
+    return _migrateProfeseFromCanvas($projectId);
+}
+
+function _rowsToProfese(array $rows): array {
+    return array_values(array_map(function($r) {
+        $p = ['name' => $r['name']];
+        if ($r['firma'])   $p['firma']   = $r['firma'];
+        if ($r['kontakt']) $p['kontakt'] = $r['kontakt'];
+        if ($r['telefon']) $p['telefon'] = $r['telefon'];
+        if ($r['color'])   $p['color']   = $r['color'];
+        if ($r['export_pinned']) $p['exportPinned'] = true;
+        if ($r['emails_json']) {
+            $emails = json_decode($r['emails_json'], true);
+            if (is_array($emails) && !empty($emails)) $p['emails'] = $emails;
+        }
+        return $p;
+    }, $rows));
+}
+
+// On first load: migrate existing profese_json from plan_canvas_data into plan_profese rows.
+function _migrateProfeseFromCanvas(int $projectId): array {
+    try {
+        $db   = getDB();
+        $stmt = $db->prepare('SELECT profese_json FROM plan_canvas_data WHERE project_id = ? LIMIT 1');
+        $stmt->execute([$projectId]);
+        $row = $stmt->fetch();
+        if (!$row || !$row['profese_json']) return [];
+
+        $val = $row['profese_json'];
+        // Decompress gzip+base64 (matches canvas.php _decompress)
+        if (strlen($val) >= 4 && str_starts_with($val, 'H4s')) {
+            $decoded = base64_decode($val, true);
+            if ($decoded !== false) {
+                $inflated = @gzdecode($decoded);
+                if ($inflated !== false) $val = $inflated;
+            }
+        }
+        $profese = json_decode($val, true);
+        if (!is_array($profese) || empty($profese)) return [];
+
+        $ins = $db->prepare(
+            'INSERT IGNORE INTO plan_profese
+                 (project_id, name, firma, emails_json, kontakt, telefon, color, export_pinned, sort_order)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)'
+        );
+        foreach ($profese as $i => $p) {
+            $name = $p['name'] ?? null;
+            if (!$name) continue;
+            $emailsJson = null;
+            if (isset($p['emails']) && is_array($p['emails'])) {
+                $emailsJson = json_encode(array_values(array_filter($p['emails'])));
+            } elseif (isset($p['email']) && $p['email']) {
+                $emailsJson = json_encode([$p['email']]);
+            }
+            $ins->execute([
+                $projectId, $name,
+                $p['firma']   ?? null,
+                $emailsJson,
+                $p['kontakt'] ?? null,
+                $p['telefon'] ?? null,
+                $p['color']   ?? null,
+                !empty($p['exportPinned']) ? 1 : 0,
+                $i,
+            ]);
+        }
+
+        $stmt2 = $db->prepare(
+            'SELECT name, firma, emails_json, kontakt, telefon, color, export_pinned, sort_order
+               FROM plan_profese WHERE project_id = ? ORDER BY sort_order, name'
+        );
+        $stmt2->execute([$projectId]);
+        return $stmt2->fetchAll();
+    } catch (\Exception $e) {
+        error_log('[profese] migration error: ' . $e->getMessage());
+        return [];
+    }
+}

--- a/index.html
+++ b/index.html
@@ -11033,7 +11033,6 @@ function _buildStateObj() {
     tool: appState.tool,
     showGrid: appState.showGrid,
     zones3D: appState.zones3D,
-    kdRecords: kdRecords,
     kdLocations: kdLocations
   };
 }
@@ -11205,6 +11204,40 @@ async function _serverLoad(projectId) {
     }
   } catch(e) {}
   return null;
+}
+
+// ---- Profese load from dedicated table ----
+async function _profServerLoad(projectId) {
+  try {
+    const { ok, data } = await apiFetch(`api/profese.php?project_id=${projectId}`);
+    if (ok && Array.isArray(data.profese)) return data.profese;
+  } catch(e) {}
+  return null;
+}
+
+// Save profese to dedicated table. Pass deletedNames for explicit removals.
+async function _saveProfese(deletedNames = []) {
+  if (!currentProject || !canEdit()) return;
+  try {
+    const formBody = 'data=' + encodeURIComponent(JSON.stringify({
+      profese: appState.profese,
+      deleted: deletedNames,
+    }));
+    const { ok, data } = await apiFetch(`api/profese.php?project_id=${currentProject.id}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: formBody,
+    });
+    // Merge back: server may have added entries from concurrent users
+    if (ok && Array.isArray(data.profese)) {
+      const localNames = new Set(appState.profese.map(p => p.name));
+      let added = false;
+      data.profese.forEach(sp => {
+        if (!localNames.has(sp.name)) { appState.profese.push(sp); added = true; }
+      });
+      if (added) { rebuildProfeseSelects(); renderProfeseList(); }
+    }
+  } catch(e) { console.error('[profese] save error:', e); }
 }
 
 function loadState() {
@@ -11473,6 +11506,7 @@ function renderProfeseList() {
       const idx = parseInt(btn.dataset.idx);
       appState.profese[idx].exportPinned = !appState.profese[idx].exportPinned;
       saveState();
+      _saveProfese(); // dedicated profese table
       renderProfeseList();
     });
   });
@@ -11511,6 +11545,7 @@ function renderProfeseList() {
       _flushSave();
       clearTimeout(_srvTimer);
       _serverSaveNow();
+      _saveProfese(); // dedicated profese table — faster, independent of canvas save
       rebuildProfeseSelects();
       renderProfeseList();
       renderHomePage();
@@ -11530,10 +11565,12 @@ function renderProfeseList() {
       }
       const confirmed = await showModal('Smazat profesi', `Opravdu smazat profesi "${prof.name}"?`);
       if (!confirmed) return;
+      const deletedName = prof.name;
       appState.profese.splice(idx, 1);
       _flushSave();
       clearTimeout(_srvTimer);
       _serverSaveNow();
+      _saveProfese([deletedName]); // explicit delete from dedicated profese table
       rebuildProfeseSelects();
       renderProfeseList();
       renderHomePage();
@@ -11557,6 +11594,7 @@ function addNewProfese() {
   _flushSave();
   clearTimeout(_srvTimer);
   _serverSaveNow();
+  _saveProfese(); // dedicated profese table
   rebuildProfeseSelects();
   renderProfeseList();
   // Open edit form for the newly added item
@@ -13301,9 +13339,10 @@ async function openProject(proj) {
 
   // Načti canvas data ze serveru (primární) nebo z localStorage (záloha)
   // Načti KD data z dedikovaného endpointu paralelně
-  const [serverData, kdServerRecords] = await Promise.all([
+  const [serverData, kdServerRecords, profServerData] = await Promise.all([
     _serverLoad(proj.id),
     _kdServerLoad(proj.id),
+    _profServerLoad(proj.id),
   ]);
 
   if (serverData) {
@@ -13333,8 +13372,10 @@ async function openProject(proj) {
         try { localStorage.setItem(LS_KD_LOCATIONS_KEY(_pid), JSON.stringify(kdLocations)); } catch(e) {}
       }
       annotIdCounter = Math.max(annotIdCounter, serverData.counter || 1);
-      if (serverData.profese && Array.isArray(serverData.profese) && serverData.profese.length > 0) {
-        appState.profese = serverData.profese;
+      if (profServerData && profServerData.length > 0) {
+        appState.profese = profServerData;
+      } else if (serverData.profese && Array.isArray(serverData.profese) && serverData.profese.length > 0) {
+        appState.profese = serverData.profese; // backward compat fallback
       }
 
       // Re-add annotations created locally but absent from server.
@@ -13384,8 +13425,10 @@ async function openProject(proj) {
         try { localStorage.setItem(LS_KD_LOCATIONS_KEY(_pid), JSON.stringify(kdLocations)); } catch(e) {}
       }
       annotIdCounter        = serverData.counter || 1;
-      if (serverData.profese && Array.isArray(serverData.profese) && serverData.profese.length > 0) {
-        appState.profese = serverData.profese;
+      if (profServerData && profServerData.length > 0) {
+        appState.profese = profServerData;
+      } else if (serverData.profese && Array.isArray(serverData.profese) && serverData.profese.length > 0) {
+        appState.profese = serverData.profese; // backward compat fallback
       }
     }
     rebuildProfeseSelects();
@@ -13408,7 +13451,9 @@ async function openProject(proj) {
     });
     return recs;
   };
-  _kdLastKdTs = kdServerRecords?.updatedAt || null;
+  _kdLastKdTs  = kdServerRecords?.updatedAt || null;
+  _lastProfTs  = null; // reset so _pollProfeseSync initialises on first cycle
+  _profPollCounter = 0;
   if (kdServerRecords?.records?.length > 0) {
     kdRecords = _kdMigrate(kdServerRecords.records);
     try { localStorage.setItem(LS_KD_KEY(String(proj.id)), JSON.stringify(kdRecords)); } catch(e) {}
@@ -13743,8 +13788,9 @@ function _isUserTyping() {
 
 async function _pollLiveSync() {
   if (!currentProject || _isProjectLoading || _saving) return;
-  // KD sync always runs — it guards its own re-renders against typing internally
+  // KD and profese sync always run independently of canvas sync
   _pollKDSync();
+  _pollProfeseSync();
   // Skip canvas sync while user has a text field focused — prevents
   // appState overwrites and DOM rebuilds from interrupting active editing.
   if (_isUserTyping()) return;
@@ -13880,7 +13926,7 @@ async function _pollLiveSync() {
 
     if (changed) updateAnnotList();
 
-    // Sync profese (supplier colors/data) when another user changed them
+    // Sync profese from canvas backup (catches changes saved together with canvas)
     if (serverData.profese && Array.isArray(serverData.profese) && serverData.profese.length > 0
         && !_hasPendingSave) {
       const remStr = JSON.stringify(serverData.profese);
@@ -13897,6 +13943,35 @@ async function _pollLiveSync() {
     }
 
   } catch(e) { /* network error – skip silently */ }
+}
+
+// Sync profese from dedicated plan_profese table (catches direct profese saves that don't
+// accompany a canvas save – e.g. another user edits profese while you have no canvas changes).
+let _lastProfTs = null;
+let _profPollCounter = 0;
+async function _pollProfeseSync() {
+  if (!currentProject || _hasPendingSave) return;
+  _profPollCounter++;
+  if (_profPollCounter % 12 !== 0) return; // run every ~60 s (12 × 5 s poll interval)
+  try {
+    const { ok, data } = await apiFetch(`api/profese.php?project_id=${currentProject.id}&ts_only=1`);
+    if (!ok || !data.updated_at) return;
+    if (_lastProfTs !== null && data.updated_at === _lastProfTs) return;
+    const prevTs = _lastProfTs;
+    _lastProfTs = data.updated_at;
+    if (prevTs === null) return; // first call — just record timestamp, don't sync
+
+    const { ok: ok2, data: data2 } = await apiFetch(`api/profese.php?project_id=${currentProject.id}`);
+    if (!ok2 || !Array.isArray(data2.profese) || !data2.profese.length) return;
+    if (JSON.stringify(data2.profese) === JSON.stringify(appState.profese)) return;
+    appState.profese = data2.profese;
+    try { localStorage.setItem(LS_PROJECT_PROFESE(String(currentProject.id)), JSON.stringify(data2.profese)); } catch(e) {}
+    rebuildProfeseSelects();
+    if (fabricCanvas) {
+      fabricCanvas.getObjects().filter(o => o.annotId).forEach(o => applyAnnotColorToCanvas(o));
+      fabricCanvas.renderAll();
+    }
+  } catch(e) { /* ignore */ }
 }
 
 async function _pollKDSync() {


### PR DESCRIPTION
- Add api/profese.php: GET/POST with concurrent-safe merge (deleted names explicitly honored, server-only entries preserved for concurrent additions) Auto-migrates from profese_json on first load per project
- Frontend loads profese from api/profese.php in parallel with canvas/KD on openProject; profese.php is primary, canvas profese_json is fallback
- All profese save actions (add, edit, pin, delete) now also POST to api/profese.php for immediate persistence independent of canvas saves
- Add _pollProfeseSync(): polls profese ts every ~60s to sync changes made by other users who only saved profese (no canvas change)
- Remove kdRecords from _buildStateObj(): KD data is already saved to plan_kd_data via kd.php; canvas blob no longer carries duplicate KD data

https://claude.ai/code/session_01Epw3iDtL3kUNnhbHKaqqCM