### PR TITLE
Normalize annotations into plan_annotations table (one row per annota…

### DIFF
--- a/api/canvas.php
+++ b/api/canvas.php
@@ -21,14 +21,38 @@ set_exception_handler(function($e) {
 
 require_once __DIR__ . '/functions.php';
 
-// Vytvoř tabulku pokud neexistuje
-getDB()->exec('CREATE TABLE IF NOT EXISTS plan_canvas_data (
+$db = getDB();
+
+// ── Tables ────────────────────────────────────────────────────
+$db->exec('CREATE TABLE IF NOT EXISTS plan_canvas_data (
     project_id    INT          NOT NULL,
     state_json    LONGTEXT,
     profese_json  MEDIUMTEXT,
     annot_counter INT          NOT NULL DEFAULT 1,
     updated_at    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     PRIMARY KEY (project_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci');
+
+$db->exec('CREATE TABLE IF NOT EXISTS plan_annotations (
+    id               INT AUTO_INCREMENT PRIMARY KEY,
+    project_id       INT          NOT NULL,
+    level_id         VARCHAR(64)  NOT NULL,
+    annot_id         VARCHAR(32)  NOT NULL,
+    fabric_json      MEDIUMTEXT   NOT NULL,
+    profese          VARCHAR(255) DEFAULT NULL,
+    popisek          MEDIUMTEXT   DEFAULT NULL,
+    priorita         VARCHAR(32)  DEFAULT NULL,
+    prirazeno        VARCHAR(255) DEFAULT NULL,
+    status           VARCHAR(32)  DEFAULT NULL,
+    deadline         VARCHAR(64)  DEFAULT NULL,
+    date_from        VARCHAR(64)  DEFAULT NULL,
+    annot_type       VARCHAR(32)  DEFAULT NULL,
+    created_at_annot VARCHAR(64)  DEFAULT NULL,
+    updated_at_annot BIGINT       NOT NULL DEFAULT 0,
+    updated_at       TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_annot (project_id, level_id, annot_id),
+    INDEX idx_project (project_id),
+    INDEX idx_level (project_id, level_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci');
 
 $user      = requireAuth();
@@ -38,20 +62,16 @@ $method    = $_SERVER['REQUEST_METHOD'];
 
 if (!$projectId) jsonError('Chybí project_id');
 
-// Ověř přístup k projektu
 $membership = getProjectMembership($projectId, $userId);
 if (!$membership) jsonError('Nemáš přístup k tomuto projektu', 403);
 
-// ============================================================
-// Komprese / dekomprese (gzip+base64, 5-10× menší data)
-// ============================================================
+// ── Compress / decompress ─────────────────────────────────────
 function _compress(string $json): string {
-    // Pokud gzip není dostupný nebo selže, ulož plain JSON
     if (function_exists('gzencode')) {
         $gz = @gzencode($json, 6);
         if ($gz !== false) return base64_encode($gz);
     }
-    return $json; // fallback – nekomprimovaný JSON
+    return $json;
 }
 
 function _decompress(string $val): string {
@@ -62,22 +82,19 @@ function _decompress(string $val): string {
             if ($inflated !== false) return $inflated;
         }
     }
-    return $val; // plain JSON nebo starý nekomprimovaný formát
+    return $val;
 }
 
-// ============================================================
-// GET – načti canvas data projektu
-// ============================================================
+// ── GET ───────────────────────────────────────────────────────
 if ($method === 'GET') {
-    // Lightweight timestamp-only poll for live sync
     if (!empty($_GET['ts_only'])) {
-        $stmt = getDB()->prepare('SELECT updated_at FROM plan_canvas_data WHERE project_id = ? LIMIT 1');
+        $stmt = $db->prepare('SELECT updated_at FROM plan_canvas_data WHERE project_id = ? LIMIT 1');
         $stmt->execute([$projectId]);
         $row = $stmt->fetch();
         jsonOk(['updated_at' => $row['updated_at'] ?? null]);
     }
 
-    $stmt = getDB()->prepare(
+    $stmt = $db->prepare(
         'SELECT state_json, profese_json, annot_counter, updated_at FROM plan_canvas_data WHERE project_id = ? LIMIT 1'
     );
     $stmt->execute([$projectId]);
@@ -87,12 +104,39 @@ if ($method === 'GET') {
         jsonOk(['state' => null, 'profese' => null, 'counter' => 1, 'updated_at' => null]);
     }
 
-    $state   = json_decode(_decompress($row['state_json']), true);
-    $profese = $row['profese_json'] ? json_decode(_decompress($row['profese_json']), true) : null;
-
+    $state = json_decode(_decompress($row['state_json']), true);
     if ($state === null) {
         jsonOk(['state' => null, 'profese' => null, 'counter' => 1, 'updated_at' => null]);
     }
+
+    // Load annotation objects from plan_annotations (auto-migrates from state_json if empty)
+    $annotsByLevel = _annotLoadOrMigrate($projectId, $state);
+
+    foreach ($state['levels'] as &$lvl) {
+        $lid  = $lvl['id'] ?? null;
+        $objs = $lid ? ($annotsByLevel[$lid] ?? []) : [];
+
+        if (!isset($lvl['fabricJSON']) || $lvl['fabricJSON'] === null) {
+            $lvl['fabricJSON'] = ['version' => '5.3.0', 'objects' => []];
+        }
+        $lvl['fabricJSON']['objects'] = $objs;
+
+        $lvl['annotations'] = array_values(array_map(fn($o) => array_filter([
+            'annotId'   => $o['annotId']   ?? null,
+            'profese'   => $o['profese']   ?? null,
+            'popisek'   => $o['popisek']   ?? null,
+            'priorita'  => $o['priorita']  ?? null,
+            'prirazeno' => $o['prirazeno'] ?? null,
+            'status'    => $o['status']    ?? null,
+            'createdAt' => $o['createdAt'] ?? null,
+            'updatedAt' => $o['updatedAt'] ?? null,
+            'deadline'  => $o['deadline']  ?? null,
+            'dateFrom'  => $o['dateFrom']  ?? null,
+        ], fn($v) => $v !== null), $objs));
+    }
+    unset($lvl);
+
+    $profese = $row['profese_json'] ? json_decode(_decompress($row['profese_json']), true) : null;
 
     jsonOk([
         'state'      => $state,
@@ -102,13 +146,8 @@ if ($method === 'GET') {
     ]);
 }
 
-// ============================================================
-// POST – ulož canvas data projektu s merge (concurrent-safe)
-// Body: { state: {...levels...}, profese: [...], counter: N }
-// ============================================================
+// ── POST ──────────────────────────────────────────────────────
 if ($method === 'POST') {
-    // Accept both application/x-www-form-urlencoded (field: data=<json>)
-    // and legacy application/json (raw body).
     $contentType = $_SERVER['CONTENT_TYPE'] ?? '';
     if (strpos($contentType, 'application/x-www-form-urlencoded') !== false) {
         $rawJson = $_POST['data'] ?? '';
@@ -126,7 +165,6 @@ if ($method === 'POST') {
 
     if ($state === null) jsonError('Chybí state');
 
-    // Odfiltruj backgroundImage z levels (příliš velká data)
     if (isset($state['levels']) && is_array($state['levels'])) {
         foreach ($state['levels'] as &$lvl) {
             unset($lvl['backgroundImage'], $lvl['backgroundImageOriginal']);
@@ -134,32 +172,130 @@ if ($method === 'POST') {
         unset($lvl);
     }
 
-    $db = getDB();
     $db->beginTransaction();
 
     try {
-        // Zamkni řádek – atomická operace (SELECT FOR UPDATE)
+        // Lock canvas row
         $stmt = $db->prepare(
             'SELECT state_json, profese_json, annot_counter FROM plan_canvas_data WHERE project_id = ? FOR UPDATE'
         );
         $stmt->execute([$projectId]);
         $existingRow = $stmt->fetch();
 
-        // Načti server stav pro merge
+        // Server level structure
         $serverLevels  = [];
         $serverCounter = 1;
         $serverProfese = [];
         if ($existingRow && $existingRow['state_json']) {
-            $serverState  = json_decode(_decompress($existingRow['state_json']), true);
-            $serverLevels = $serverState['levels'] ?? [];
+            $serverState   = json_decode(_decompress($existingRow['state_json']), true);
+            $serverLevels  = $serverState['levels'] ?? [];
             $serverCounter = (int)($existingRow['annot_counter'] ?? 1);
         }
         if ($existingRow && $existingRow['profese_json']) {
             $serverProfese = json_decode(_decompress($existingRow['profese_json']), true) ?? [];
         }
 
-        // Merge každého levelu – zachová anotace přidané jiným uživatelem
-        $clientLevels = $state['levels'] ?? [];
+        // Load all server annotations for this project (for merge / serverAdded)
+        $stmtAnn = $db->prepare(
+            'SELECT level_id, annot_id, fabric_json, updated_at_annot FROM plan_annotations WHERE project_id = ?'
+        );
+        $stmtAnn->execute([$projectId]);
+        $serverAnnotRows = $stmtAnn->fetchAll();
+
+        // Index: [level_id][annot_id] => row
+        $srvAnnotMap = [];
+        foreach ($serverAnnotRows as $ar) {
+            $srvAnnotMap[$ar['level_id']][$ar['annot_id']] = $ar;
+        }
+
+        // Process client levels – collect annotation upserts and serverAdded
+        $clientLevels      = $state['levels'] ?? [];
+        $clientLevelIds    = [];
+        $clientAnnotSet    = []; // [level_id][annot_id] = true
+        $annotUpserts      = [];
+        $serverAddedByLvl  = []; // [level_id] => [objects]
+
+        foreach ($clientLevels as $cl) {
+            $lid = $cl['id'] ?? null;
+            if (!$lid) continue;
+            $clientLevelIds[] = $lid;
+            $clientAnnotSet[$lid] = [];
+
+            foreach ($cl['fabricJSON']['objects'] ?? [] as $obj) {
+                $aid = $obj['annotId'] ?? null;
+                if (!$aid) continue;
+                $clientAnnotSet[$lid][$aid] = true;
+
+                $clientTs = (int)($obj['updatedAt'] ?? 0);
+                $srvRow   = $srvAnnotMap[$lid][$aid] ?? null;
+                $serverTs = $srvRow ? (int)$srvRow['updated_at_annot'] : 0;
+
+                if ($srvRow && $serverTs > $clientTs) {
+                    // Server is newer — keep DB value; client will see it on next poll
+                    continue;
+                }
+
+                // Client is newer or annotation is new → upsert
+                $fjson = json_encode($obj, JSON_UNESCAPED_UNICODE | JSON_PARTIAL_OUTPUT_ON_ERROR);
+                if (!$fjson || $fjson === 'null') continue;
+                $annotUpserts[] = [
+                    $projectId, $lid, $aid, $fjson,
+                    $obj['profese']   ?? null,
+                    $obj['popisek']   ?? null,
+                    $obj['priorita']  ?? null,
+                    $obj['prirazeno'] ?? null,
+                    $obj['status']    ?? null,
+                    $obj['deadline']  ?? null,
+                    $obj['dateFrom']  ?? null,
+                    $obj['annotType'] ?? null,
+                    $obj['createdAt'] ?? null,
+                    $clientTs,
+                ];
+            }
+        }
+
+        // Find server-only annotations for each submitted level → serverAdded
+        foreach ($clientLevelIds as $lid) {
+            foreach ($srvAnnotMap[$lid] ?? [] as $aid => $srvRow) {
+                if (!isset($clientAnnotSet[$lid][$aid])) {
+                    $srvObj = json_decode($srvRow['fabric_json'], true);
+                    if ($srvObj) $serverAddedByLvl[$lid][] = $srvObj;
+                }
+            }
+        }
+        $serverAdded = [];
+        foreach ($serverAddedByLvl as $lid => $objs) {
+            $serverAdded[] = ['levelId' => $lid, 'objects' => $objs];
+        }
+
+        // Execute annotation upserts
+        if (!empty($annotUpserts)) {
+            $ins = $db->prepare(
+                'INSERT INTO plan_annotations
+                     (project_id, level_id, annot_id, fabric_json,
+                      profese, popisek, priorita, prirazeno, status,
+                      deadline, date_from, annot_type, created_at_annot, updated_at_annot)
+                 VALUES (?,?,?,?, ?,?,?,?,?, ?,?,?,?,?)
+                 ON DUPLICATE KEY UPDATE
+                   fabric_json      = IF(VALUES(updated_at_annot)>=updated_at_annot, VALUES(fabric_json),      fabric_json),
+                   profese          = IF(VALUES(updated_at_annot)>=updated_at_annot, VALUES(profese),          profese),
+                   popisek          = IF(VALUES(updated_at_annot)>=updated_at_annot, VALUES(popisek),          popisek),
+                   priorita         = IF(VALUES(updated_at_annot)>=updated_at_annot, VALUES(priorita),         priorita),
+                   prirazeno        = IF(VALUES(updated_at_annot)>=updated_at_annot, VALUES(prirazeno),        prirazeno),
+                   status           = IF(VALUES(updated_at_annot)>=updated_at_annot, VALUES(status),           status),
+                   deadline         = IF(VALUES(updated_at_annot)>=updated_at_annot, VALUES(deadline),         deadline),
+                   date_from        = IF(VALUES(updated_at_annot)>=updated_at_annot, VALUES(date_from),        date_from),
+                   annot_type       = IF(VALUES(updated_at_annot)>=updated_at_annot, VALUES(annot_type),       annot_type),
+                   created_at_annot = IF(VALUES(updated_at_annot)>=updated_at_annot, VALUES(created_at_annot), created_at_annot),
+                   updated_at_annot = IF(VALUES(updated_at_annot)>=updated_at_annot, VALUES(updated_at_annot), updated_at_annot),
+                   updated_at       = NOW()'
+            );
+            foreach ($annotUpserts as $params) {
+                $ins->execute($params);
+            }
+        }
+
+        // Merge level STRUCTURE (no annotation objects in state_json)
         $serverLevelMap = [];
         foreach ($serverLevels as $sl) {
             if (!empty($sl['id'])) $serverLevelMap[$sl['id']] = $sl;
@@ -169,66 +305,53 @@ if ($method === 'POST') {
             if (!empty($cl['id'])) $clientLevelMap[$cl['id']] = $cl;
         }
 
-        // serverAdded: objekty ze serveru, které klient neměl – vrátíme klientovi
-        $serverAdded = [];
-
         $mergedLevels = [];
         foreach ($clientLevels as $cl) {
-            $id = $cl['id'] ?? null;
-            if ($id && isset($serverLevelMap[$id])) {
-                $sl = $serverLevelMap[$id];
-
-                // Merge fabricJSON.objects by annotId
-                $clientObjs = $cl['fabricJSON']['objects'] ?? [];
-                $serverObjs = $sl['fabricJSON']['objects'] ?? [];
-                [$mergedObjs, $serverOnlyObjs] = _mergeCanvasObjects($serverObjs, $clientObjs);
-
-                // Merge annotations by annotId
-                $clientAnnots = $cl['annotations'] ?? [];
-                $serverAnnots = $sl['annotations'] ?? [];
-                [$mergedAnnots] = _mergeCanvasAnnotations($serverAnnots, $clientAnnots);
-
-                $merged = $cl;
-                if (isset($cl['fabricJSON']) && $cl['fabricJSON'] !== null) {
-                    $merged['fabricJSON'] = array_merge($cl['fabricJSON'], ['objects' => $mergedObjs]);
-                }
-                $merged['annotations'] = $mergedAnnots;
-                $mergedLevels[] = $merged;
-
-                if (!empty($serverOnlyObjs)) {
-                    $serverAdded[] = ['levelId' => $id, 'objects' => $serverOnlyObjs];
-                }
-            } else {
-                $mergedLevels[] = $cl;
+            $id     = $cl['id'] ?? null;
+            $merged = $cl;
+            // Strip annotation data — stored in plan_annotations, not state_json
+            if (isset($merged['fabricJSON']) && $merged['fabricJSON'] !== null) {
+                $merged['fabricJSON'] = [
+                    'version'    => $merged['fabricJSON']['version']    ?? '5.3.0',
+                    'background' => $merged['fabricJSON']['background'] ?? '#f0f0ec',
+                ];
             }
+            unset($merged['annotations']);
+            $mergedLevels[] = $merged;
         }
 
-        // Zachovej levely přítomné pouze na serveru (přidal jiný uživatel)
+        // Preserve server-only levels (added by another user)
         foreach ($serverLevels as $sl) {
             $id = $sl['id'] ?? null;
             if ($id && !isset($clientLevelMap[$id])) {
-                $mergedLevels[] = $sl;
+                $sl2 = $sl;
+                if (isset($sl2['fabricJSON'])) {
+                    $sl2['fabricJSON'] = [
+                        'version'    => $sl2['fabricJSON']['version']    ?? '5.3.0',
+                        'background' => $sl2['fabricJSON']['background'] ?? '#f0f0ec',
+                    ];
+                }
+                unset($sl2['annotations']);
+                $mergedLevels[] = $sl2;
             }
         }
 
-        $mergedState           = $state;
-        $mergedState['levels'] = $mergedLevels;
-        $newCounter            = max($counter, $serverCounter);
+        $mergedState            = $state;
+        $mergedState['levels']  = $mergedLevels;
+        $newCounter             = max($counter, $serverCounter);
 
-        // Serializuj JSON – JSON_PARTIAL_OUTPUT_ON_ERROR jako pojistka pro bad UTF-8
         $stateJson = json_encode($mergedState, JSON_UNESCAPED_UNICODE | JSON_PARTIAL_OUTPUT_ON_ERROR);
         if ($stateJson === false || $stateJson === 'null') {
             $db->rollBack();
             jsonError('Chyba serializace stavu: ' . json_last_error_msg(), 500);
         }
 
-        // Merge profese: client wins per name, server-only entries preserved.
-        // Prevents a stale client from silently deleting profese added by another user.
+        // Merge profese (still kept in profese_json as backup)
         $mergedProfese = null;
         if ($profese !== null) {
             $mergedProfese = _mergeProfese($serverProfese, $profese);
         } elseif (!empty($serverProfese)) {
-            $mergedProfese = $serverProfese; // client sent nothing – keep server data
+            $mergedProfese = $serverProfese;
         }
 
         $profeseJson = null;
@@ -237,7 +360,7 @@ if ($method === 'POST') {
             if ($profeseJson === false) $profeseJson = null;
         }
 
-        $stateCompressed   = _compress($stateJson);
+        $stateCompressed  = _compress($stateJson);
         $proteseCompressed = $profeseJson !== null ? _compress($profeseJson) : null;
 
         if (empty($stateCompressed)) {
@@ -246,21 +369,16 @@ if ($method === 'POST') {
         }
 
         if ($existingRow) {
-            $db->prepare('
-                UPDATE plan_canvas_data
-                SET state_json = ?, profese_json = ?, annot_counter = ?, updated_at = NOW()
-                WHERE project_id = ?
-            ')->execute([$stateCompressed, $proteseCompressed, $newCounter, $projectId]);
+            $db->prepare(
+                'UPDATE plan_canvas_data SET state_json=?, profese_json=?, annot_counter=?, updated_at=NOW() WHERE project_id=?'
+            )->execute([$stateCompressed, $proteseCompressed, $newCounter, $projectId]);
         } else {
-            $db->prepare('
-                INSERT INTO plan_canvas_data (project_id, state_json, profese_json, annot_counter)
-                VALUES (?, ?, ?, ?)
-            ')->execute([$projectId, $stateCompressed, $proteseCompressed, $newCounter]);
+            $db->prepare(
+                'INSERT INTO plan_canvas_data (project_id, state_json, profese_json, annot_counter) VALUES (?,?,?,?)'
+            )->execute([$projectId, $stateCompressed, $proteseCompressed, $newCounter]);
         }
 
         $db->commit();
-
-        // Vrať serverAdded klientovi – přidá chybějící anotace do canvasu
         jsonOk(['saved' => strlen($stateCompressed), 'serverAdded' => $serverAdded, 'counter' => $newCounter]);
 
     } catch (Exception $e) {
@@ -269,119 +387,77 @@ if ($method === 'POST') {
     }
 }
 
-// ============================================================
-// Merge helpers – canvas objects / annotations by annotId
-// server = co je na serveru; client = co posílá klient
-// client vítězí pro shodné annotId (last-write-wins per object)
-// server-only items jsou zachovány (přidal jiný uživatel)
-// Returns: [mergedArray, serverOnlyItems]
-// ============================================================
-// Merge profese arrays: client version wins per name (last-write-wins),
-// server-only entries (added by another user) are appended so they are never lost.
+jsonError('Metoda není povolena', 405);
+
+// ── Helpers ───────────────────────────────────────────────────
+
+// Merge profese arrays: client wins per name, server-only entries preserved.
 function _mergeProfese(array $server, array $client): array {
     $clientByName = [];
     foreach ($client as $p) {
         $name = $p['name'] ?? null;
         if ($name !== null) $clientByName[$name] = $p;
     }
-    $merged = $client; // start with all client entries (client wins for matching names)
+    $merged = $client;
     foreach ($server as $p) {
         $name = $p['name'] ?? null;
-        if ($name !== null && !isset($clientByName[$name])) {
-            $merged[] = $p; // server-only entry – preserve it
-        }
+        if ($name !== null && !isset($clientByName[$name])) $merged[] = $p;
     }
     return $merged;
 }
 
-function _mergeCanvasObjects(array $serverObjs, array $clientObjs): array {
-    // Build server map for quick lookup by annotId
-    $serverMap = [];
-    foreach ($serverObjs as $o) {
-        $aid = $o['annotId'] ?? null;
-        if ($aid) $serverMap[$aid] = $o;
-    }
-    $clientIds = [];
-    foreach ($clientObjs as $o) {
-        $aid = $o['annotId'] ?? null;
-        if ($aid) $clientIds[$aid] = true;
+// Load annotations from plan_annotations, grouped by level_id.
+// If the table is empty for this project, auto-migrate from embedded state_json objects
+// (one-time, transparent to the caller).
+function _annotLoadOrMigrate(int $projectId, array &$state): array {
+    $db   = getDB();
+    $stmt = $db->prepare(
+        'SELECT level_id, annot_id, fabric_json FROM plan_annotations WHERE project_id = ? ORDER BY id'
+    );
+    $stmt->execute([$projectId]);
+    $rows = $stmt->fetchAll();
+
+    if (!empty($rows)) {
+        $byLevel = [];
+        foreach ($rows as $r) {
+            $obj = json_decode($r['fabric_json'], true);
+            if ($obj) $byLevel[$r['level_id']][] = $obj;
+        }
+        return $byLevel;
     }
 
-    $merged = [];
-    $serverOnly = [];
-    foreach ($clientObjs as $o) {
-        $aid = $o['annotId'] ?? null;
-        if ($aid && isset($serverMap[$aid])) {
-            $srv = $serverMap[$aid];
-            $clientTs = (int)($o['updatedAt']  ?? 0);
-            $serverTs = (int)($srv['updatedAt'] ?? 0);
-            if ($serverTs > $clientTs) {
-                // Server annotation is newer — use server's field values
-                foreach (['popisek', 'prirazeno', 'profese', 'priorita', 'status', 'deadline', 'dateFrom'] as $tf) {
-                    $o[$tf] = $srv[$tf] ?? $o[$tf];
-                }
-                $o['updatedAt'] = $serverTs;
-            } elseif ($clientTs === 0 && $serverTs === 0) {
-                // Legacy (no timestamps): preserve server non-empty text fields
-                foreach (['popisek', 'prirazeno'] as $tf) {
-                    if (empty($o[$tf]) && !empty($srv[$tf])) $o[$tf] = $srv[$tf];
-                }
-            }
-            // clientTs >= serverTs and at least one has timestamp: client is newer, keep as-is
+    // Migration: extract annotation objects from embedded state_json
+    $byLevel = [];
+    $ins = $db->prepare(
+        'INSERT IGNORE INTO plan_annotations
+             (project_id, level_id, annot_id, fabric_json,
+              profese, popisek, priorita, prirazeno, status,
+              deadline, date_from, annot_type, created_at_annot, updated_at_annot)
+         VALUES (?,?,?,?, ?,?,?,?,?, ?,?,?,?,?)'
+    );
+    foreach ($state['levels'] as $lvl) {
+        $lid = $lvl['id'] ?? null;
+        if (!$lid) continue;
+        foreach ($lvl['fabricJSON']['objects'] ?? [] as $obj) {
+            $aid = $obj['annotId'] ?? null;
+            if (!$aid) continue;
+            $fjson = json_encode($obj, JSON_UNESCAPED_UNICODE);
+            if (!$fjson) continue;
+            $ins->execute([
+                $projectId, $lid, $aid, $fjson,
+                $obj['profese']   ?? null,
+                $obj['popisek']   ?? null,
+                $obj['priorita']  ?? null,
+                $obj['prirazeno'] ?? null,
+                $obj['status']    ?? null,
+                $obj['deadline']  ?? null,
+                $obj['dateFrom']  ?? null,
+                $obj['annotType'] ?? null,
+                $obj['createdAt'] ?? null,
+                (int)($obj['updatedAt'] ?? 0),
+            ]);
+            $byLevel[$lid][] = $obj;
         }
-        $merged[] = $o;
     }
-    foreach ($serverObjs as $o) {
-        $aid = $o['annotId'] ?? null;
-        if ($aid && !isset($clientIds[$aid])) {
-            $merged[]     = $o;
-            $serverOnly[] = $o;
-        }
-    }
-    return [$merged, $serverOnly];
+    return $byLevel;
 }
-
-function _mergeCanvasAnnotations(array $serverAnnots, array $clientAnnots): array {
-    $serverMap = [];
-    foreach ($serverAnnots as $a) {
-        $aid = $a['annotId'] ?? null;
-        if ($aid) $serverMap[$aid] = $a;
-    }
-    $clientIds = [];
-    foreach ($clientAnnots as $a) {
-        $aid = $a['annotId'] ?? null;
-        if ($aid) $clientIds[$aid] = true;
-    }
-
-    $merged = [];
-    $serverOnly = [];
-    foreach ($clientAnnots as $a) {
-        $aid = $a['annotId'] ?? null;
-        if ($aid && isset($serverMap[$aid])) {
-            $srv = $serverMap[$aid];
-            $clientTs = (int)($a['updatedAt']  ?? 0);
-            $serverTs = (int)($srv['updatedAt'] ?? 0);
-            if ($serverTs > $clientTs) {
-                foreach (['popisek', 'prirazeno', 'profese', 'priorita', 'status', 'deadline', 'dateFrom'] as $tf) {
-                    $a[$tf] = $srv[$tf] ?? $a[$tf];
-                }
-                $a['updatedAt'] = $serverTs;
-            } elseif ($clientTs === 0 && $serverTs === 0) {
-                foreach (['popisek', 'prirazeno'] as $tf) {
-                    if (empty($a[$tf]) && !empty($srv[$tf])) $a[$tf] = $srv[$tf];
-                }
-            }
-        }
-        $merged[] = $a;
-    }
-    foreach ($serverAnnots as $a) {
-        $aid = $a['annotId'] ?? null;
-        if ($aid && !isset($clientIds[$aid])) {
-            $merged[]     = $a;
-            $serverOnly[] = $a;
-        }
-    }
-    return [$merged, $serverOnly];
-}
-
-jsonError('Metoda není povolena', 405);


### PR DESCRIPTION
…tion)

Previously all fabric.js objects were gzipped into a single state_json blob, causing full-blob lock contention and complex PHP-side merge on every save.

New architecture:
- plan_annotations table: one row per annotation (annotId UNIQUE per project/level)
- state_json now stores only canvas structure: level metadata, viewport, bg params. fabricJSON.objects is empty in the DB blob — objects live in plan_annotations.
- canvas.php GET: loads level structure from plan_canvas_data, loads annotation objects from plan_annotations, injects them back into fabricJSON.objects per level. Auto-migrates existing embedded objects on first load (INSERT IGNORE, race-safe).
- canvas.php POST: extracts annotation objects from each level's fabricJSON.objects, upserts each to plan_annotations with per-row timestamp comparison in MySQL (IF(VALUES(updated_at_annot)>=updated_at_annot, client, server)), saves lighter state_json without objects. serverAdded still returned for newly-seen annotations.
- Two users editing DIFFERENT annotations no longer conflict at all.
- Two users editing the SAME annotation: last updatedAt timestamp wins.
- profese_json in state_json kept as backup (primary is now plan_profese via profese.php).
- API interface (request/response format) unchanged — no frontend changes needed.

https://claude.ai/code/session_01Epw3iDtL3kUNnhbHKaqqCM