### PR TITLE
Fix profese sync delay and richer-data overwrite protection

### DIFF
--- a/api/profese.php
+++ b/api/profese.php
@@ -131,23 +131,50 @@ if ($method === 'POST') {
         foreach ($toUpsert as $i => $p) {
             $name = $p['name'] ?? null;
             if (!$name) continue;
+
+            // Current server row for this profese (used for merge logic below)
+            $sv = $existingByName[$name] ?? null;
+
             if (isset($p['_emails_json'])) {
+                // Server-only entry re-inserted unchanged
                 $emailsJson = $p['_emails_json'];
-            } elseif (isset($p['emails']) && is_array($p['emails'])) {
-                $emailsJson = json_encode(array_values(array_filter($p['emails'])));
-            } elseif (isset($p['email'])) {
-                $emailsJson = is_array($p['email'])
-                    ? json_encode(array_values(array_filter($p['email'])))
-                    : json_encode(array_filter([$p['email']]));
+                $firma   = $p['firma']   ?? null;
+                $kontakt = $p['kontakt'] ?? null;
+                $telefon = $p['telefon'] ?? null;
             } else {
-                $emailsJson = null;
+                // Client-submitted entry: resolve emails and text fields
+                if (isset($p['emails']) && is_array($p['emails'])) {
+                    $clientEmails = array_values(array_filter($p['emails']));
+                } elseif (isset($p['email'])) {
+                    $clientEmails = is_array($p['email'])
+                        ? array_values(array_filter($p['email']))
+                        : array_values(array_filter([$p['email']]));
+                } else {
+                    $clientEmails = [];
+                }
+
+                // Emails: always union — never discard addresses the server already has
+                if ($sv && $sv['emails_json']) {
+                    $serverEmails = json_decode($sv['emails_json'], true) ?: [];
+                    $merged = array_values(array_unique(array_merge($serverEmails, $clientEmails)));
+                } else {
+                    $merged = $clientEmails;
+                }
+                $emailsJson = !empty($merged) ? json_encode($merged) : null;
+
+                // Text fields: prefer client value when non-empty, fall back to server
+                // so a stale device never blanks out data a richer device already saved
+                $firma   = ($p['firma']   ?? '') !== '' ? $p['firma']   : ($sv['firma']   ?? null);
+                $kontakt = ($p['kontakt'] ?? '') !== '' ? $p['kontakt'] : ($sv['kontakt'] ?? null);
+                $telefon = ($p['telefon'] ?? '') !== '' ? $p['telefon'] : ($sv['telefon'] ?? null);
             }
+
             $ins->execute([
                 $projectId, $name,
-                $p['firma']   ?? null,
+                $firma,
                 $emailsJson,
-                $p['kontakt'] ?? null,
-                $p['telefon'] ?? null,
+                $kontakt,
+                $telefon,
                 $p['color']   ?? null,
                 !empty($p['exportPinned']) ? 1 : 0,
                 $i,

--- a/index.html
+++ b/index.html
@@ -13091,6 +13091,15 @@ function toggleHomePage(forceState) {
     } else {
       closeAnotacePage(); toggleUsersPage(false); closeKDPage();
       hp.classList.add('visible'); btn.classList.add('active'); renderHomePage();
+      // Refresh profese from server when opening so edits from other devices are visible
+      if (currentProject) _profServerLoad(currentProject.id).then(profs => {
+        if (!Array.isArray(profs) || !profs.length) return;
+        if (JSON.stringify(profs) === JSON.stringify(appState.profese)) return;
+        appState.profese = profs;
+        _lastProfTs = null; // reset so next poll cycle records fresh timestamp
+        try { localStorage.setItem(LS_PROJECT_PROFESE(String(currentProject.id)), JSON.stringify(profs)); } catch(e) {}
+        rebuildProfeseSelects(); renderHomePage();
+      }).catch(() => {});
     }
   }
   updateMobileNavBar();
@@ -14150,9 +14159,9 @@ async function _pollLiveSync() {
 let _lastProfTs = null;
 let _profPollCounter = 0;
 async function _pollProfeseSync() {
-  if (!currentProject || _hasPendingSave) return;
+  if (!currentProject) return;
   _profPollCounter++;
-  if (_profPollCounter % 12 !== 0) return; // run every ~60 s (12 × 5 s poll interval)
+  if (_profPollCounter % 5 !== 0) return; // run every ~10 s (5 × 2 s poll interval)
   try {
     const { ok, data } = await apiFetch(`api/profese.php?project_id=${currentProject.id}&ts_only=1`);
     if (!ok || !data.updated_at) return;


### PR DESCRIPTION
Sync:
- Remove _hasPendingSave guard from _pollProfeseSync — canvas saves no longer block profese sync (it's a GET-only operation)
- Reduce poll throttle from every 24 s to every 10 s
- Trigger immediate server refresh when Subdodavatelé page is opened so changes from other devices are visible before the user starts editing

Save logic (profese.php):
- Emails: always merge client + server arrays (union) so a stale device can never discard email addresses the server already stored
- firma/kontakt/telefon: prefer non-empty value — if client sends empty but server has a value, the server value is preserved


Claude-Session: https://claude.ai/code/session_01Epw3iDtL3kUNnhbHKaqqCM