### PR TITLE
Remove toggleHomePage profese server fetch — it was the source of ema…

### DIFF
--- a/index.html
+++ b/index.html
@@ -11432,19 +11432,20 @@ async function _saveProfese(deletedNames = []) {
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: formBody,
     });
-    // Apply server-confirmed state only if no newer save has fired since this one
+    // Save confirmed by server — mark as clean and add any server-only entries
     if (ok && Array.isArray(data.profese) && seq === _profSaveSeq) {
-      // Replace full state with server's authoritative response (includes union-merged emails etc.)
-      appState.profese = data.profese;
-      _profSaveDoneSeq++;   // signal: GET responses older than this carry stale data
-      _lastProfTs = null; // reset so next poll cycle just records new ts, no redundant load
+      _profSaveDoneSeq++;
+      _lastProfTs = null;
+      // Add entries that exist only on server (e.g. added by another device)
+      const localNames = new Set(appState.profese.map(p => p.name));
+      data.profese.forEach(sp => {
+        if (!localNames.has(sp.name)) appState.profese.push(sp);
+      });
       const _pid = String(currentProject.id);
       try {
         localStorage.setItem(LS_PROJECT_PROFESE(_pid), JSON.stringify(appState.profese));
-        localStorage.removeItem(LS_PROJECT_PROFESE_DIRTY(_pid)); // confirmed by server
+        localStorage.removeItem(LS_PROJECT_PROFESE_DIRTY(_pid));
       } catch(e) {}
-      rebuildProfeseSelects();
-      renderProfeseList();
     }
   } catch(e) { console.error('[profese] save error:', e); }
   finally { if (seq === _profSaveSeq) _hasPendingProfSave = false; }
@@ -13104,22 +13105,6 @@ function toggleHomePage(forceState) {
     } else {
       closeAnotacePage(); toggleUsersPage(false); closeKDPage();
       hp.classList.add('visible'); btn.classList.add('active'); renderHomePage();
-      // Refresh profese from server when opening so edits from other devices are visible.
-      // Capture _profSaveDoneSeq BEFORE sending GET — if a save completes while the GET
-      // is in-flight, the GET may carry data from before the commit; skip it in that case.
-      if (currentProject) {
-        const _doneSeqAtFetch = _profSaveDoneSeq;
-        _profServerLoad(currentProject.id).then(profs => {
-          if (!Array.isArray(profs) || !profs.length) return;
-          if (_hasPendingProfSave) return; // POST still in-flight — local is authoritative
-          if (_profSaveDoneSeq !== _doneSeqAtFetch) return; // save completed after GET was sent — GET may be stale
-          if (JSON.stringify(profs) === JSON.stringify(appState.profese)) return;
-          appState.profese = profs;
-          _lastProfTs = null; // reset so next poll cycle records fresh timestamp
-          try { localStorage.setItem(LS_PROJECT_PROFESE(String(currentProject.id)), JSON.stringify(profs)); } catch(e) {}
-          rebuildProfeseSelects(); renderHomePage();
-        }).catch(() => {});
-      }
     }
   }
   updateMobileNavBar();


### PR DESCRIPTION
…il loss

Every time the user opened the home page, _profServerLoad() fired async. This GET request could race the _saveProfese() POST on the server side — the GET arrived before the POST committed, returned stale data (no email), then resolved after all guards had cleared and overwrote appState.profese.

Fix: remove the _profServerLoad call from toggleHomePage entirely. _pollProfeseSync (every 10 s) is sufficient for cross-device sync. The local appState.profese is authoritative immediately after save.

Also simplify _saveProfese() response handler: instead of replacing the whole array with server data (which could differ in key order or fields and trigger spurious re-renders), only append server-only entries that aren't already in local state.


Claude-Session: https://claude.ai/code/session_01Epw3iDtL3kUNnhbHKaqqCM