### PR TITLE
Fix SQL syntax: move ORDER BY before FOR UPDATE in profese save query

### DIFF
--- a/api/profese.php
+++ b/api/profese.php
@@ -80,7 +80,7 @@ if ($method === 'POST') {
     try {
         $stmt = $db->prepare(
             'SELECT name, firma, emails_json, kontakt, telefon, color, export_pinned, sort_order
-               FROM plan_profese WHERE project_id = ? FOR UPDATE ORDER BY sort_order, name'
+               FROM plan_profese WHERE project_id = ? ORDER BY sort_order, name FOR UPDATE'
         );
         $stmt->execute([$projectId]);
         $existing = $stmt->fetchAll();


### PR DESCRIPTION
MariaDB requires ORDER BY to come before the FOR UPDATE locking clause. The previous order (FOR UPDATE ORDER BY) caused a syntax error on every profese save, silently blocking all writes to the database.


Claude-Session: https://claude.ai/code/session_01Epw3iDtL3kUNnhbHKaqqCM