### PR TITLE
Fix btoa crash on Czech/Unicode profese names in Vizitka URL

### DIFF
--- a/api/vcard.php
+++ b/api/vcard.php
@@ -5,9 +5,10 @@ error_reporting(0);
 
 require_once __DIR__ . '/functions.php';
 
-// Support single base64-encoded param ?d=... (avoids & in URL breaking mobile PDF viewers)
+// Support single URL-encoded JSON param ?d=... (avoids & in URL breaking mobile PDF viewers)
+// PHP $_GET auto-decodes the URL encoding, so json_decode directly works
 if (!empty($_GET['d'])) {
-    $parsed    = json_decode(base64_decode($_GET['d']), true) ?: [];
+    $parsed    = json_decode($_GET['d'], true) ?: [];
     $projectId = (int)($parsed['p'] ?? 0);
     $name      = trim($parsed['n'] ?? '');
     $token     = $parsed['t'] ?? '';

--- a/index.html
+++ b/index.html
@@ -10217,8 +10217,8 @@ function drawDochazkaPDF(pdf, rec, pdfLogo, PW, PH) {
     pdf.setFont('helvetica', 'bold'); pdf.setFontSize(Math.max(3.5, ROW_FS * 0.82)); pdf.setTextColor(255, 255, 255);
     pdf.text('Vizitka', _vBtnX + _vBtnW / 2, _vBtnY + _vBtnH * 0.72, { align: 'center' });
     if (_profeseVcfToken && currentProject) {
-      // Encode all params as single base64 blob — avoids & in URL which breaks mobile PDF viewers
-      const _vcfD   = encodeURIComponent(btoa(JSON.stringify({ p: currentProject.id, n: p.name, t: _profeseVcfToken })));
+      // Encode all params as single URL-encoded JSON — no & in URL, works with Unicode names
+      const _vcfD   = encodeURIComponent(JSON.stringify({ p: currentProject.id, n: p.name, t: _profeseVcfToken }));
       const _vcfUrl = window.location.origin + '/api/vcard.php?d=' + _vcfD;
       pdf.link(_vBtnX, _vBtnY, _vBtnW, _vBtnH, { url: _vcfUrl });
     }


### PR DESCRIPTION
btoa() fails on strings with characters outside Latin-1 (e.g. á, č, ě). Replace btoa(JSON.stringify) with encodeURIComponent(JSON.stringify) — PHP's \$_GET auto-decodes the URL encoding so json_decode() works directly.


Claude-Session: https://claude.ai/code/session_01Epw3iDtL3kUNnhbHKaqqCM