### PR TITLE
fix: KD section headers always visible when scrolling right

### DIFF
--- a/index.html
+++ b/index.html
@@ -1571,7 +1571,7 @@ option { background: var(--card); color: var(--text); }
   flex: 1; display: flex; flex-direction: column; overflow: hidden;
 }
 #kd-cards-scroll {
-  flex: 1; overflow-x: auto; overflow-y: auto;
+  flex: 1; overflow-x: auto; overflow-y: hidden;
 }
 #kd-cards-inner {
   display: flex; flex-direction: column; gap: 18px;
@@ -1588,7 +1588,10 @@ option { background: var(--card); color: var(--text); }
   width: 420px; min-width: 240px; background: var(--panel);
   border: 1px solid var(--border); border-radius: 8px;
   display: flex; flex-direction: column; flex-shrink: 0;
-  max-height: calc(100vh - 160px); box-shadow: 0 1px 4px rgba(0,0,0,0.06);
+  /* 100vh minus: topbar(48) + kd-page bottom(26) + meta-bar(~40)
+     + filter-bar(~42) + inner-padding(28) = ~184px; use 195 for safety */
+  max-height: calc(100vh - 195px);
+  box-shadow: 0 1px 4px rgba(0,0,0,0.06);
   overflow: hidden;
 }
 .kd-card-header {

--- a/index.html
+++ b/index.html
@@ -1571,7 +1571,7 @@ option { background: var(--card); color: var(--text); }
   flex: 1; display: flex; flex-direction: column; overflow: hidden;
 }
 #kd-cards-scroll {
-  flex: 1; overflow-x: auto; overflow-y: hidden;
+  flex: 1; overflow-x: auto; overflow-y: auto;
 }
 #kd-cards-inner {
   display: flex; flex-direction: column; gap: 18px;


### PR DESCRIPTION
Root cause: #kd-cards-scroll had overflow-y:auto which let the outer container scroll vertically. Card max-height calc(100vh-160px) was too large (~22px taller than available space), so a small vertical scrollbar appeared. When horizontally scrolled, the headers were already scrolled just out of the visible top edge.

Fix:
- #kd-cards-scroll: overflow-y:hidden (outer container no longer scrolls vertically; each card's .kd-tasks-list handles its own internal vertical scroll independently)
- .kd-card max-height: calc(100vh-195px) to properly account for topbar(48) + kd-page bottom(26) + meta-bar(~40) + filter-bar(~42)
  + inner padding(28)