### PR TITLE
Fix completedAt missing from API response; name KD chrome height cons…

### DIFF
--- a/api/canvas.php
+++ b/api/canvas.php
@@ -122,16 +122,17 @@ if ($method === 'GET') {
         $lvl['fabricJSON']['objects'] = $objs;
 
         $lvl['annotations'] = array_values(array_map(fn($o) => array_filter([
-            'annotId'   => $o['annotId']   ?? null,
-            'profese'   => $o['profese']   ?? null,
-            'popisek'   => $o['popisek']   ?? null,
-            'priorita'  => $o['priorita']  ?? null,
-            'prirazeno' => $o['prirazeno'] ?? null,
-            'status'    => $o['status']    ?? null,
-            'createdAt' => $o['createdAt'] ?? null,
-            'updatedAt' => $o['updatedAt'] ?? null,
-            'deadline'  => $o['deadline']  ?? null,
-            'dateFrom'  => $o['dateFrom']  ?? null,
+            'annotId'     => $o['annotId']     ?? null,
+            'profese'     => $o['profese']     ?? null,
+            'popisek'     => $o['popisek']     ?? null,
+            'priorita'    => $o['priorita']    ?? null,
+            'prirazeno'   => $o['prirazeno']   ?? null,
+            'status'      => $o['status']      ?? null,
+            'createdAt'   => $o['createdAt']   ?? null,
+            'updatedAt'   => $o['updatedAt']   ?? null,
+            'completedAt' => $o['completedAt'] ?? null,
+            'deadline'    => $o['deadline']    ?? null,
+            'dateFrom'    => $o['dateFrom']    ?? null,
         ], fn($v) => $v !== null), $objs));
     }
     unset($lvl);

--- a/index.html
+++ b/index.html
@@ -55,6 +55,8 @@
   --vlastni: #6B7280;
   --font-mono: 'IBM Plex Mono', monospace;
   --font-main: 'Barlow Condensed', sans-serif;
+  /* KD board: fixed chrome above cards (topbar 48 + bottom-pad 26 + meta-bar ~40 + filter-bar ~42 + inner-pad 28 + buffer 11) */
+  --kd-cards-chrome: 195px;
 }
 #annot-tooltip {
   display: none;
@@ -1588,9 +1590,7 @@ option { background: var(--card); color: var(--text); }
   width: 420px; min-width: 240px; background: var(--panel);
   border: 1px solid var(--border); border-radius: 8px;
   display: flex; flex-direction: column; flex-shrink: 0;
-  /* 100vh minus: topbar(48) + kd-page bottom(26) + meta-bar(~40)
-     + filter-bar(~42) + inner-padding(28) = ~184px; use 195 for safety */
-  max-height: calc(100vh - 195px);
+  max-height: calc(100vh - var(--kd-cards-chrome));
   box-shadow: 0 1px 4px rgba(0,0,0,0.06);
   overflow: hidden;
 }


### PR DESCRIPTION
…tant

canvas.php GET whitelist omitted completedAt, so the Dokonceno column always showed dash after page reload even though the value was stored in fabric_json. Adds completedAt to the annotation summary map (closes #262).

Replaces the magic 195 in calc(100vh - 195px) with --kd-cards-chrome CSS variable defined and documented in :root (closes #263).