### PR TITLE
fix: sticky section-header chips ztrácely zarovnání se sloupci od dru…

### DIFF
--- a/index.html
+++ b/index.html
@@ -12614,14 +12614,11 @@ function kdApplyZoom() {
   document.querySelectorAll('#kd-cards-inner .kd-chapter-cards').forEach(el => {
     el.style.zoom = String(_kdZoom);
   });
-  // Sync sticky chip widths/gap to match zoomed card columns
-  const chipW = Math.round(_kdCardWidth * _kdZoom) + 'px';
-  const chipGap = Math.round(12 * _kdZoom) + 'px';
+  // Sticky chip bar keeps its unzoomed px width/gap (set in kdBuildChapter)
+  // and gets the same `zoom` applied here — identical browser scaling as
+  // the real row, so columns stay aligned instead of drifting per-chip.
   document.querySelectorAll('#kd-cards-inner .kd-card-headers-bar-inner').forEach(inner => {
-    inner.style.gap = chipGap;
-    inner.querySelectorAll('.kd-card-hdr-chip').forEach(chip => {
-      chip.style.width = chipW; chip.style.minWidth = chipW;
-    });
+    inner.style.zoom = String(_kdZoom);
   });
   _kdUpdateSectionBar();
 }
@@ -12999,15 +12996,18 @@ function kdBuildChapter(rec, ch, isLive) {
   hdr.appendChild(hdrInner);
   el.appendChild(hdr);
 
-  // Sticky section-names bar (outside zoom — CSS sticky works here)
+  // Sticky section-names bar. Mirrors the real card row using the same
+  // unzoomed px width/gap as .kd-chapter-cards/.kd-card — kdApplyZoom()
+  // then applies the identical `zoom` factor to both, so they scale
+  // through the same browser math and stay pixel-aligned at any zoom
+  // level (manually rounding px per chip drifted more with each column).
   const hdrsBar = document.createElement('div'); hdrsBar.className = 'kd-card-headers-bar';
   const hdrsBarInner = document.createElement('div'); hdrsBarInner.className = 'kd-card-headers-bar-inner';
-  hdrsBarInner.style.gap = Math.round(12 * _kdZoom) + 'px';
+  hdrsBarInner.style.gap = '12px';
   (ch.cards || []).forEach(card => {
     const chip = document.createElement('div'); chip.className = 'kd-card-hdr-chip';
     chip.dataset.cardId = card.id; chip.textContent = card.title || 'Úsek';
-    const chipW = Math.round(_kdCardWidth * _kdZoom) + 'px';
-    chip.style.width = chipW; chip.style.minWidth = chipW;
+    chip.style.width = _kdCardWidth + 'px'; chip.style.minWidth = '240px';
     hdrsBarInner.appendChild(chip);
   });
   hdrsBar.appendChild(hdrsBarInner);


### PR DESCRIPTION
…hé sekce dál

kd-card-headers-bar (sticky lišta s názvy sekcí) počítala šířku/mezeru chipů ručně (Math.round(_kdCardWidth * zoom)), zatímco reálné karty se škálovaly přes CSS zoom. Zaokrouhlování se u každého sloupce sčítalo, takže zarovnání postupně ujíždělo doprava. Teď chipy používají stejné nezoomované px hodnoty jako karty a zoom se na ně aplikuje stejným způsobem (stejná CSS zoom matematika) — ověřeno v Playwright testu: posun 0/0.41/0.81/1.22/1.63/2.03 px u sloupců 1-6 → 0 px u všech.