### PR TITLE
fix: unify KD chapter header appearance at all horizontal scroll posi…

### DIFF
--- a/index.html
+++ b/index.html
@@ -12632,12 +12632,17 @@ function _kdUpdateSectionBar() {
   const scrollTop = scroll.getBoundingClientRect().top;
   const scrollLeft = scroll.scrollLeft;
 
-  // Keep chapter headers anchored at the left edge when horizontal scroll is active.
-  // position:sticky top:0 handles vertical; we compensate horizontal manually
-  // because the element's natural left is always 0 (CSS sticky:left won't trigger).
+  // Keep chapter headers AND section-name chips bars anchored at the left viewport
+  // edge when the board scrolls horizontally. position:sticky handles vertical;
+  // we compensate horizontal manually (CSS sticky:left won't trigger here).
+  // Always apply the translateX (even at 0) to avoid a visual jump at scrollLeft=0.
   const isMobile = window.innerWidth <= 768;
+  const tx = !isMobile ? `translateX(${scrollLeft}px)` : '';
   document.querySelectorAll('#kd-cards-inner .kd-chapter-header').forEach(el => {
-    el.style.transform = (!isMobile && scrollLeft > 0) ? `translateX(${scrollLeft}px)` : '';
+    el.style.transform = tx;
+  });
+  document.querySelectorAll('#kd-cards-inner .kd-card-headers-bar').forEach(el => {
+    el.style.transform = tx;
   });
 
   const CHAPTER_HDR_H = 42; // .kd-chapter-header is ~42px, sticks at top:0


### PR DESCRIPTION
…tions

_kdUpdateSectionBar() applied translateX(scrollLeft) to chapter headers only when scrollLeft > 0, causing a visual jump/inconsistency when crossing scroll position 0. Fix:
- Always apply translateX (even 0px at rest) so the header position is consistent regardless of scroll state
- Apply the same correction to .kd-card-headers-bar (section-name chips bar) which had no horizontal compensation at all — causing the chips to scroll out of view when the board was scrolled right


Claude-Session: https://claude.ai/code/session_01Epw3iDtL3kUNnhbHKaqqCM