### PR TITLE
feat: add construction symbol tool with dropdown picker

### DIFF
--- a/index.html
+++ b/index.html
@@ -337,6 +337,32 @@ body {
 }
 
 /* TOOLBAR BUTTONS */
+/* SYMBOL PICKER POPUP */
+#symbol-picker-popup {
+  display: none; position: fixed; z-index: 9000;
+  background: var(--panel); border: 1px solid var(--border);
+  border-radius: 10px; padding: 8px;
+  box-shadow: 0 6px 24px rgba(0,0,0,0.28); width: 256px;
+}
+#symbol-picker-popup.open { display: block; }
+.sym-picker-title {
+  font-size: 9px; font-family: var(--font-mono); color: var(--text-dim);
+  text-transform: uppercase; letter-spacing: .06em;
+  padding: 0 2px 6px; border-bottom: 1px solid var(--border); margin-bottom: 6px;
+}
+.sym-picker-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 4px; }
+.sym-picker-item {
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  gap: 3px; padding: 6px 2px; border-radius: 7px; cursor: pointer;
+  border: 1px solid transparent; transition: background .12s, border-color .12s;
+}
+.sym-picker-item:hover { background: var(--hover); border-color: var(--border); }
+.sym-picker-item.active { border-color: var(--olive); background: rgba(74,83,64,.15); }
+.sym-picker-item svg { width: 30px; height: 30px; }
+.sym-picker-item span {
+  font-size: 8px; color: var(--text-dim); text-align: center;
+  line-height: 1.2; max-width: 44px;
+}
 #toolbar-right {
   display: flex;
   align-items: center;
@@ -4016,6 +4042,11 @@ body.viewer-mode #kd-backup-next { display: none !important; }
     <button class="tb-btn tool-btn desktop-only-tool" id="tool-levellink" data-tool="levellink" title="Proklik na výkres (K)">
       <svg viewBox="0 0 24 24" fill="none" stroke="#06B6D4" stroke-width="2"><line x1="3" y1="12" x2="17" y2="12" stroke-dasharray="4 2.5"/><polyline points="13 8 17 12 13 16"/><circle cx="3" cy="12" r="1.8" fill="#06B6D4" stroke="none"/></svg>
     </button>
+    <button class="tb-btn" id="tool-symbol" title="Symbol stavební činnosti">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <polygon points="12,3 20,8 20,16 12,21 4,16 4,8"/><line x1="12" y1="9" x2="12" y2="15"/><line x1="9" y1="12" x2="15" y2="12"/>
+      </svg>
+    </button>
     <div class="tb-separator"></div>
     <button class="tb-btn" id="zoom-in-btn" title="Přiblížit (+)">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/><line x1="11" y1="8" x2="11" y2="14"/><line x1="8" y1="11" x2="14" y2="11"/></svg>
@@ -4049,6 +4080,11 @@ body.viewer-mode #kd-backup-next { display: none !important; }
     <button class="tb-btn" id="model-3d-btn" title="3D Model">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
     </button>
+  </div>
+  <!-- Symbol picker popup (position:fixed, outside overflow:hidden toolbar) -->
+  <div id="symbol-picker-popup">
+    <div class="sym-picker-title">Symbol stavební činnosti</div>
+    <div class="sym-picker-grid" id="sym-picker-grid"></div>
   </div>
   <button id="mobile-menu-btn" onclick="toggleMobileMenu()" title="Menu" aria-label="Menu">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="20" height="20"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
@@ -5960,6 +5996,7 @@ function setupDrawingEditor() {
 // ============================================================
 function setTool(tool) {
   _exitMoveMode();
+  if (tool !== 'symbol') _symPickerClose();
   if ((appState.tool === 'polygon' || appState.tool === 'polyline') && tool !== appState.tool) {
     cancelPolygon();
   }
@@ -6800,7 +6837,10 @@ function setupEventListeners() {
 
     const color = getActiveProfeseColor();
 
-    if (appState.tool === 'pin') {
+    if (appState.tool === 'symbol') {
+      isDrawing = false;
+      placeSymbolAt(pointer.x, pointer.y);
+    } else if (appState.tool === 'pin') {
       isDrawing = false;
       placePinAt(pointer.x, pointer.y);
     } else if (appState.tool === 'text') {
@@ -7319,6 +7359,12 @@ function setupEventListeners() {
       if (btn.classList.contains('mob-tool')) closeMobileMenu();
     });
   });
+  // Symbol picker button — toggle popup (not a tool-btn, handled separately)
+  document.getElementById('tool-symbol').addEventListener('click', e => {
+    e.stopPropagation();
+    const popup = document.getElementById('symbol-picker-popup');
+    if (popup.classList.contains('open')) _symPickerClose(); else _symPickerOpen();
+  });
 
   document.getElementById('zoom-in-btn').addEventListener('click', () => zoomBy(1.25));
   document.getElementById('zoom-out-btn').addEventListener('click', () => zoomBy(0.8));
@@ -7722,6 +7768,105 @@ function createArrow(x1, y1, x2, y2, color) {
     strokeLineCap: 'round'
   });
   return line;
+}
+
+// ══════════════════════════════════════════════════════════════
+// SYMBOL TOOL — construction activity symbols
+// ══════════════════════════════════════════════════════════════
+const SYMBOL_DEFS = [
+  { key: 'crane',     label: 'Jeřáb',         d: 'M 1 10 L 1 -9 M 1 -9 L -9 -9 M 1 -9 L 5 -9 M -9 -9 L 1 -5 M -4 -9 L -4 -1 M -6 0 L -4 -1 L -2 0' },
+  { key: 'excavator', label: 'Rypadlo',        d: 'M -8 10 L 8 10 L 8 7 L -8 7 Z M -5 7 L -5 2 L 3 2 L 3 7 M 3 4 L 7 -2 M 7 -2 L 9 -6 L 6 -7 L 7 -2' },
+  { key: 'mixer',     label: 'Betonmixy',      d: 'M -6 10 A 2 2 0 1 0 -2 10 M 2 10 A 2 2 0 1 0 6 10 M -7 8 L 7 8 L 7 3 L -5 3 Z M -1 3 L 1 -7 L 5 -7 L 6 3 M 7 6 L 10 9' },
+  { key: 'truck',     label: 'Nákl. auto',     d: 'M -9 8 A 2 2 0 1 0 -5 8 M 4 8 A 2 2 0 1 0 8 8 M -9 6 L 5 6 L 5 0 L 1 0 L 1 2 L -9 2 Z M 5 6 L 10 6 L 10 1 L 5 0' },
+  { key: 'scaffold',  label: 'Lešení',         d: 'M -7 10 L -7 -10 M 0 10 L 0 -10 M 7 10 L 7 -10 M -7 5 L 7 5 M -7 0 L 7 0 M -7 -5 L 7 -5 M -7 5 L 0 0 M 0 5 L 7 0 M -7 0 L 0 -5 M 0 0 L 7 -5' },
+  { key: 'helmet',    label: 'Přilba',         d: 'M -7 1 A 7 9 0 0 1 7 1 L 9 3 L -9 3 Z M -2 3 L -2 7 L 2 7 L 2 3' },
+  { key: 'electric',  label: 'Elektrika',      d: 'M 4 -10 L -2 0 L 2 0 L -4 10 L 10 -2 L 5 -2 Z' },
+  { key: 'plumbing',  label: 'Instalace',      d: 'M -1 10 L -1 -2 L 1 -2 L 1 10 M -5 -2 L 5 -2 L 5 -5 L -5 -5 Z M 0 -5 L 0 -9 M -3 -7 L 3 -7' },
+  { key: 'welding',   label: 'Svařování',      d: 'M -8 9 L 3 -2 M 3 -2 L 5 -4 L 9 -4 L 7 -2 Z M 7 -4 L 5 -8 M 7 -4 L 9 -8 M 7 -4 L 10 -5' },
+  { key: 'barrier',   label: 'Zápora',         d: 'M -10 -1 L 10 -1 L 10 3 L -10 3 Z M -8 -1 L -4 3 M -2 -1 L 2 3 M 4 -1 L 8 3 M -10 -1 L -10 -8 M 10 -1 L 10 -8' },
+  { key: 'drill',     label: 'Vrtání',         d: 'M 0 -10 L 0 7 M -4 7 L 4 7 L 0 11 Z M -3 -3 Q 1 -5 -3 -7 M 3 -5 Q -1 -7 3 -9' },
+  { key: 'concrete',  label: 'Betonáž',        d: 'M -7 -8 L -3 4 L 3 4 L 7 -8 Z M -1 4 L -1 10 M 1 4 L 1 10 M -3 7 L 3 7' },
+  { key: 'survey',    label: 'Měření',         d: 'M -5 -5 A 5 5 0 1 0 5 -5 A 5 5 0 0 0 -5 -5 M 0 0 L 0 5 M -9 10 L 0 5 L 9 10 M -6 10 L 6 10' },
+  { key: 'material',  label: 'Materiál',       d: 'M -8 10 L 8 10 L 8 8 L -8 8 Z M -6 8 L -6 5 L 6 5 L 6 8 M -6 6 L 6 6 M -6 5 L -6 2 L 6 2 L 6 5 M -6 3 L 6 3 M 0 5 L 0 2 M 0 8 L 0 10' },
+  { key: 'hoist',     label: 'Stav. výtah',    d: 'M -8 10 L -8 -10 M 8 10 L 8 -10 M -8 -6 L 8 -6 M -8 -2 L 8 -2 M -8 2 L 8 2 M -8 6 L 8 6 M -5 -2 L -5 2 L 5 2 L 5 -2 Z' },
+];
+let _pendingSymbolKey = 'crane';
+
+function _symPickerBuild() {
+  const grid = document.getElementById('sym-picker-grid');
+  if (!grid || grid.children.length) return;
+  SYMBOL_DEFS.forEach(sym => {
+    const el = document.createElement('div');
+    el.className = 'sym-picker-item' + (sym.key === _pendingSymbolKey ? ' active' : '');
+    el.dataset.key = sym.key;
+    el.title = sym.label;
+    el.innerHTML = `<svg viewBox="-12 -12 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="${sym.d}"/></svg><span>${sym.label}</span>`;
+    el.addEventListener('click', e => { e.stopPropagation(); _symSelect(sym.key); });
+    grid.appendChild(el);
+  });
+}
+
+function _symPickerOpen() {
+  _symPickerBuild();
+  const btn = document.getElementById('tool-symbol');
+  const popup = document.getElementById('symbol-picker-popup');
+  const r = btn.getBoundingClientRect();
+  popup.style.top  = (r.bottom + 4) + 'px';
+  popup.style.right = (window.innerWidth - r.right) + 'px';
+  popup.classList.add('open');
+  setTimeout(() => {
+    const handler = e => {
+      if (!popup.contains(e.target) && e.target.id !== 'tool-symbol') {
+        _symPickerClose();
+        document.removeEventListener('mousedown', handler);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+  }, 0);
+}
+
+function _symPickerClose() {
+  const p = document.getElementById('symbol-picker-popup');
+  if (p) p.classList.remove('open');
+}
+
+function _symSelect(key) {
+  _pendingSymbolKey = key;
+  document.querySelectorAll('.sym-picker-item').forEach(el =>
+    el.classList.toggle('active', el.dataset.key === key));
+  _symPickerClose();
+  // Activate symbol tool
+  appState.tool = 'symbol';
+  fabricCanvas.isDrawingMode = false;
+  fabricCanvas.defaultCursor = 'crosshair';
+  document.querySelectorAll('.tool-btn').forEach(b => b.classList.remove('active'));
+  document.getElementById('tool-symbol').classList.add('active');
+}
+
+function placeSymbolAt(x, y) {
+  const sym = SYMBOL_DEFS.find(s => s.key === _pendingSymbolKey) || SYMBOL_DEFS[0];
+  const color = getActiveProfeseColor();
+  const shape = new fabric.Path(sym.d, {
+    left: x, top: y,
+    originX: 'center', originY: 'center',
+    fill: 'transparent',
+    stroke: color, strokeWidth: 1.8, strokeUniform: true,
+    strokeLineCap: 'round', strokeLineJoin: 'round',
+    scaleX: 2, scaleY: 2,
+    selectable: true,
+  });
+  addAnnotationProperties(shape, 'symbol');
+  shape.annotSymbol = sym.key;
+  fabricCanvas.add(shape);
+  createAnnotLabel(shape);
+  fabricCanvas.setActiveObject(shape);
+  pushUndoState();
+  updateAnnotList();
+  onObjectSelected({ target: shape });
+  setTool('select');
+  saveCurrentLevel();
+  clearTimeout(_srvTimer); _serverSaveNow();
+  fabricCanvas.renderAll();
 }
 
 function updateActiveAnnotProp(prop, value) {
@@ -11424,6 +11569,7 @@ function saveCurrentLevel() {
     createdAt: o.createdAt || null, updatedAt: o.updatedAt || null,
     deadline: o.deadline || null, dateFrom: o.dateFrom || null,
     completedAt: o.completedAt || null,
+    annotSymbol: o.annotSymbol || null,
     linkToLevel: o.linkToLevel || null
   }));
 


### PR DESCRIPTION
- Add 15 construction symbols (crane, excavator, mixer, truck, scaffold, helmet, electric, plumbing, welding, barrier, drill, concrete, survey, material, hoist) as SVG paths
- Symbol picker popup with 5-column grid, positioned fixed so it clears toolbar overflow:hidden clip
- Selected symbol placed as fabric.Path in active contractor color with full annotation metadata (annotId, profese, status, etc.)
- annotSymbol field saved in saveCurrentLevel() snapshot
- setTool() closes picker when switching to any other tool
- Symbol button in toolbar-right; picker toggles on click
- Canvas performance: label O(1) cache, rAF-batched rendering, deferred setCoords in deconflict loop, O(n) applyHotovoVisibility
- completedAt column in annotation overview table
- KD board chapter header horizontal-scroll alignment fix
- Top bar cascading media queries for narrow desktop widths


Claude-Session: https://claude.ai/code/session_01Epw3iDtL3kUNnhbHKaqqCM