### PR TITLE
Redesign all symbols as bold filled silhouettes (26 total)

### DIFF
--- a/index.html
+++ b/index.html
@@ -7798,51 +7798,65 @@ function createArrow(x1, y1, x2, y2, color) {
 const SYMBOL_DEFS = [
   // ── Těžká technika ──────────────────────────────────────────────────────────
   { key: 'crane', label: 'Jeřáb', d:
-    'M -1.5 10 L -1.5 -8 L 1.5 -8 L 1.5 10 Z ' +
-    'M 1.5 -8 L 10 -8 L 10 -5.5 L 1.5 -5.5 Z ' +
-    'M -6 -8 L -1.5 -8 L -1.5 -5.5 L -6 -5.5 Z ' +
-    'M 8.5 -5.5 L 9.5 -5.5 L 9.5 0 L 8.5 0 Z ' +
-    'M 7.5 0 L 10.5 0 L 10.5 2 L 7.5 2 Z'
+    'M -1.5 10 L -1.5 -7 L 1.5 -7 L 1.5 10 Z ' +
+    'M -1.5 -7 L 0 -11 L 1.5 -7 Z ' +
+    'M 1.5 -10 L 10 -10 L 10 -7 L 1.5 -7 Z ' +
+    'M -7 -10 L -1.5 -10 L -1.5 -7 L -7 -7 Z ' +
+    'M 8.5 -7 L 9.5 -7 L 9.5 -1 L 8.5 -1 Z ' +
+    'M 7.5 -1 L 10.5 -1 L 10.5 1 L 7.5 1 Z'
   },
   { key: 'excavator', label: 'Rypadlo', d:
-    'M -8 10 L 8 10 L 8 7 L -8 7 Z ' +
-    'M -6 7 L 1 7 L 1 3 L -6 3 Z ' +
-    'M 1 5.5 L 8 2.5 L 7 0.5 L 0 3.5 Z ' +
-    'M 7.5 2 L 10 -1 L 8 -2 L 5.5 1 Z ' +
-    'M 7 -1 L 11 -1 L 11 -4.5 L 7 -4.5 Z'
+    'M -10 10 L 10 10 L 10 8 L -10 8 Z ' +
+    'M -9 8 L 9 8 L 9 6 L -9 6 Z ' +
+    'M -7 6 L 3 6 L 3 2 L -7 2 Z ' +
+    'M 3 5 L 8 3 L 7 1 L 2 3 Z ' +
+    'M 8 3 L 11 -1 L 9 -2 L 6 2 Z ' +
+    'M 8.5 -1 L 11 -1.5 L 11 -5 L 8.5 -4.5 Z'
   },
   { key: 'mixer', label: 'Betonmixér', d:
-    'M -8 10 L 4 10 L 4 6 L -8 6 Z ' +
-    'M 4 9 L 9 9 L 9 5 L 4 5 Z ' +
-    'M -5 6 Q -5 0 0 -4 Q 5 0 5 6 Z ' +
-    'M -7 10 Q -7 12 -4.5 12 Q -2 12 -2 10 Z ' +
-    'M 5 10 Q 5 12 7.5 12 Q 10 12 10 10 Z'
+    'M -9 9 L 4 9 L 4 6 L -9 6 Z ' +
+    'M 4 8 L 10 8 L 10 5 L 4 5 Z ' +
+    'M -5 6 Q -5 0 0 -3 Q 5 0 5 6 Z ' +
+    'M 0 -3 L 2 -7 L -2 -7 Z ' +
+    'M -7.5 9 Q -7.5 11 -5 11 Q -2.5 11 -2.5 9 Z ' +
+    'M 3 9 Q 3 11 5.5 11 Q 8 11 8 9 Z ' +
+    'M 7 9 Q 7 11 9.5 11 Q 12 11 12 9 Z'
   },
-  { key: 'truck', label: 'Nákl. auto', d:
-    'M -9 8 L 4 8 L 4 3 L -9 3 Z ' +
-    'M 4 8 L 9 8 L 9 3 L 4 3 Z ' +
+  { key: 'truck', label: 'Sklápěč', d:
+    'M -9 8 L 3 8 L 3 3 L -9 3 Z ' +
+    'M 3 8 L 9 8 L 9 3 L 3 3 Z ' +
+    'M -9 3 L 1 3 L 1 -1 L -9 -1 Z ' +
     'M -7.5 8 Q -7.5 11 -5 11 Q -2.5 11 -2.5 8 Z ' +
-    'M 5.5 8 Q 5.5 11 8 11 Q 10.5 11 10.5 8 Z'
+    'M 4.5 8 Q 4.5 11 7 11 Q 9.5 11 9.5 8 Z'
   },
-  { key: 'bulldozer', label: 'Buldozer', d:
-    'M -7 8 L 5 8 L 5 5 L -7 5 Z ' +
-    'M -5 5 L 3 5 L 3 1 L -5 1 Z ' +
-    'M 3 4 L 6 4 L 8 1 L 3 1 Z ' +
-    'M -10 3.5 L 8 3.5 L 8 5.5 L -10 5.5 Z'
+  { key: 'bulldozer', label: 'Nakladač', d:
+    'M -9 9 L 7 9 L 7 7 L -9 7 Z ' +
+    'M -7 7 L 5 7 L 5 3 L -7 3 Z ' +
+    'M 5 6 L 8 6 L 10 3 L 5 3 Z ' +
+    'M 8 9 L 11 9 L 11 1 L 8 1 Z ' +
+    'M -8 9 Q -8 11 -5.5 11 Q -3 11 -3 9 Z ' +
+    'M 3 9 Q 3 11 5.5 11 Q 8 11 8 9 Z'
   },
   { key: 'forklift', label: 'Vysokozdvižný', d:
-    'M -7 7 L 3 7 L 3 2 L -7 2 Z ' +
-    'M 3 7 L 8 7 L 8 3 L 3 3 Z ' +
-    'M -6 7 Q -6 10 -3.5 10 Q -1 10 -1 7 Z ' +
-    'M 5.5 7 Q 5.5 10 8 10 Q 10.5 10 10.5 7 Z ' +
-    'M -9 -9 L -7 -9 L -7 4 L -9 4 Z ' +
-    'M -9 -9 L -4 -9 L -4 -7 L -9 -7 Z'
+    'M -9 8 L 5 8 L 5 3 L -9 3 Z ' +
+    'M 5 8 L 10 8 L 10 4 L 5 4 Z ' +
+    'M -7.5 8 Q -7.5 11 -5 11 Q -2.5 11 -2.5 8 Z ' +
+    'M 5.5 8 Q 5.5 11 8 11 Q 10.5 11 10.5 8 Z ' +
+    'M -9 -10 L -7 -10 L -7 3 L -9 3 Z ' +
+    'M -9 -10 L -4 -10 L -4 -8 L -9 -8 Z'
   },
   // ── Bezpečnost & osoby ──────────────────────────────────────────────────────
   { key: 'helmet', label: 'Přilba', d:
-    'M 0 -9 Q 8.5 -9 8.5 0 L -8.5 0 Q -8.5 -9 0 -9 Z ' +
-    'M -9.5 0 L 9.5 0 L 9.5 3 L -9.5 3 Z ' +
+    'M 0 -9 Q 9 -9 9 0 L -9 0 Q -9 -9 0 -9 Z ' +
+    'M -10 0 L 10 0 L 10 3 L -10 3 Z ' +
     'M -1.5 3 L 1.5 3 L 1.5 7 L -1.5 7 Z'
+  },
+  { key: 'cone', label: 'Doprav. kužel', d:
+    'M -6 10 L 6 10 L 1.5 2 L -1.5 2 Z ' +
+    'M -1.5 2 L 1.5 2 L 0.5 -2 L -0.5 -2 Z ' +
+    'M -0.5 -2 L 0.5 -2 L 0 -5 Z ' +
+    'M -7.5 10 L 7.5 10 L 7.5 11.5 L -7.5 11.5 Z ' +
+    'M -4 5 L 4 5 L 4 6.5 L -4 6.5 Z'
   },
   { key: 'worker', label: 'Pracovník', d:
     'M 0 -10 Q 3.5 -10 3.5 -6.5 Q 3.5 -3 0 -3 Q -3.5 -3 -3.5 -6.5 Q -3.5 -10 0 -10 Z ' +
@@ -7852,38 +7866,34 @@ const SYMBOL_DEFS = [
     'M -4 5 L -5 10 L -2 10 L -1 5 Z ' +
     'M 4 5 L 5 10 L 2 10 L 1 5 Z'
   },
-  { key: 'warning', label: 'Upozornění', d:
-    'M 0 -10 L 10 8 L -10 8 Z ' +
-    'M -1.5 2 L 1.5 2 L 1.5 5 L -1.5 5 Z ' +
-    'M -1.5 -3 L 1.5 -3 L 1.5 0 L -1.5 0 Z'
+  // ── Bezpečnost (pokračování) ────────────────────────────────────────────────
+  { key: 'gloves', label: 'Rukavice', d:
+    'M -7 8 Q -7 0 0 -1 L 2 -1 L 3 -6 L 8 -3 L 6 1 Q 8 1 8 6 L 8 8 Z ' +
+    'M -7 8 L 8 8 L 8 10 L -7 10 Z'
   },
   // ── Elektro & energie ───────────────────────────────────────────────────────
   { key: 'electric', label: 'Elektrika', d:
     'M 3 -10 L -3 -1 L 1.5 -1 L -5 10 L 11 -1 L 5.5 -1 Z'
   },
-  { key: 'generator', label: 'Generátor', d:
-    'M -8 -6 L 8 -6 L 8 6 L -8 6 Z ' +
-    'M -3 -6 L 3 -6 L 3 -10 L -3 -10 Z ' +
-    'M -5 6 L -3 6 L -3 10 L -5 10 Z ' +
-    'M 3 6 L 5 6 L 5 10 L 3 10 Z ' +
-    'M -1.5 -3 L 1.5 -3 L 0 3 Z'
-  },
   // ── Instalace & potrubí ─────────────────────────────────────────────────────
   { key: 'plumbing', label: 'Voda/Potrubí', d:
-    'M -2 10 L -2 3 L -6 3 L -6 -3 L -2 -3 L -2 -7 L 2 -7 L 2 -3 L 6 -3 L 6 3 L 2 3 L 2 10 Z'
+    'M -9 -2.5 L 9 -2.5 L 9 2.5 L -9 2.5 Z ' +
+    'M -2.5 -9 L 2.5 -9 L 2.5 9 L -2.5 9 Z'
   },
   { key: 'waterdrop', label: 'Vodoinstalace', d:
     'M 0 -10 Q 7 -3 7 3 Q 7 9 0 9 Q -7 9 -7 3 Q -7 -3 0 -10 Z'
   },
   // ── Zemní práce & vrtání ────────────────────────────────────────────────────
-  { key: 'drill', label: 'Vrtání', d:
-    'M -3 -10 L 3 -10 L 3 4 L -3 4 Z ' +
-    'M -5 4 L 5 4 L 0 10 Z ' +
-    'M -3 -10 Q 0 -7 3 -10 L 3 -8 Q 0 -5 -3 -8 Z'
+  { key: 'jackhammer', label: 'Sbíječka', d:
+    'M -7 -9 L 7 -9 L 7 -6 L -7 -6 Z ' +
+    'M -4 -6 L 4 -6 L 4 1 L -4 1 Z ' +
+    'M -3 1 L 3 1 L 3 4 L -3 4 Z ' +
+    'M -1.5 4 L 1.5 4 L 1.5 10 L -1.5 10 Z'
   },
-  { key: 'shovel', label: 'Výkop', d:
-    'M -2.5 -10 L 2.5 -10 L 2.5 0 L -2.5 0 Z ' +
-    'M -6 0 L 6 0 L 3.5 10 L -3.5 10 Z'
+  { key: 'shovel', label: 'Lopata/Výkop', d:
+    'M -2 -10 L 2 -10 L 2 -1 L -2 -1 Z ' +
+    'M -2 -1 L 2 -1 L 2 1 L -2 1 Z ' +
+    'M -6 1 L 6 1 L 3.5 10 L -3.5 10 Z'
   },
   // ── Stavební konstrukce ─────────────────────────────────────────────────────
   { key: 'scaffold', label: 'Lešení', d:
@@ -7900,19 +7910,32 @@ const SYMBOL_DEFS = [
     'M 3 -2 L 9 -2 L 9 2 L 3 2 Z ' +
     'M -9 4 L 9 4 L 9 8 L -9 8 Z'
   },
-  { key: 'stairs', label: 'Schody', d:
-    'M -8 10 L -8 4 L -4 4 L -4 -1 L 0 -1 L 0 -6 L 4 -6 L 4 -10 L 8 -10 L 8 10 Z'
+  { key: 'house', label: 'Stavba domu', d:
+    'M 0 -10 L 10 -2 L 8 -2 L 8 9 L -8 9 L -8 -2 L -10 -2 Z ' +
+    'M -3 9 L -3 2 L 3 2 L 3 9 Z'
   },
   { key: 'barrier', label: 'Zápora/Pažení', d:
-    'M -9 -3 L 9 -3 L 9 3 L -9 3 Z ' +
-    'M -9 3 L -7 3 L -7 9 L -9 9 Z ' +
-    'M 7 3 L 9 3 L 9 9 L 7 9 Z'
+    'M -9 -1 L 9 -1 L 9 3 L -9 3 Z ' +
+    'M -10 3 L -8 3 L -8 9 L -10 9 Z ' +
+    'M 8 3 L 10 3 L 10 9 L 8 9 Z'
   },
   { key: 'hoist', label: 'Stav. výtah', d:
     'M -7 -10 L -5 -10 L -5 10 L -7 10 Z ' +
     'M 5 -10 L 7 -10 L 7 10 L 5 10 Z ' +
     'M -5 -6 L 5 -6 L 5 0 L -5 0 Z ' +
     'M -8 8 L 8 8 L 8 10 L -8 10 Z'
+  },
+  // ── Nástroje ────────────────────────────────────────────────────────────────
+  { key: 'saw', label: 'Pila', d:
+    'M -9 -4 L 9 -4 L 12 -2 L 9 0 L 9 2 L -9 2 Z ' +
+    'M -8 2 L -6 2 L -7 5 Z ' +
+    'M -4 2 L -2 2 L -3 5 Z ' +
+    'M 0 2 L 2 2 L 1 5 Z ' +
+    'M 4 2 L 6 2 L 5 5 Z'
+  },
+  { key: 'hammer', label: 'Kladivo', d:
+    'M -7 8 L -9 6 L 1 -4 L 3 -2 Z ' +
+    'M -1 -6 L 1 -8 L 7 -2 L 5 0 Z'
   },
   // ── Dokončovací práce ───────────────────────────────────────────────────────
   { key: 'concrete', label: 'Betonáž', d:
@@ -7924,20 +7947,11 @@ const SYMBOL_DEFS = [
     'M -9 -3 Q -6 -6 -3 -3 Q 0 0 3 -3 Q 6 -6 9 -3 L 9 0 Q 6 -3 3 0 Q 0 3 -3 0 Q -6 -3 -9 0 Z ' +
     'M -9 2 Q -6 -1 -3 2 Q 0 5 3 2 Q 6 -1 9 2 L 9 5 Q 6 2 3 5 Q 0 8 -3 5 Q -6 2 -9 5 Z'
   },
-  { key: 'paint', label: 'Malování', d:
-    'M -8 -7 L 4 -7 L 4 1 L -8 1 Z ' +
-    'M -6 -9 L 6 -9 L 6 -7 L -6 -7 Z ' +
-    'M 4 -2 L 8 -2 L 8 5 L 6 5 L 6 -1 L 4 -1 Z ' +
-    'M 4 5 L 8 5 L 8 10 L 4 10 Z'
-  },
   // ── Měření & kontrola ───────────────────────────────────────────────────────
-  { key: 'survey', label: 'Měření/Geodézie', d:
-    'M -1.5 10 L 1.5 10 L 1.5 5 L -1.5 5 Z ' +
-    'M -7 10 L -1.5 5 L 1.5 5 L -4 10 Z ' +
-    'M 7 10 L 1.5 5 L -1.5 5 L 4 10 Z ' +
-    'M -4 5 L 4 5 L 4 -1 L -4 -1 Z ' +
-    'M -6 -1 L 6 -1 L 6 -3 L -6 -3 Z ' +
-    'M -1 -3 L 1 -3 L 1 -7 L -1 -7 Z'
+  { key: 'tape', label: 'Metr/Pásmo', fillRule: 'evenodd', d:
+    'M 6 0 Q 6 7 -1 7 Q -8 7 -8 0 Q -8 -7 -1 -7 Q 6 -7 6 0 Z ' +
+    'M 2 0 Q 2 3 -1 3 Q -4 3 -4 0 Q -4 -3 -1 -3 Q 2 -3 2 0 Z ' +
+    'M 6 -2 L 10 -2 L 10 4 L 6 4 Z'
   },
   // ── Svařování ───────────────────────────────────────────────────────────────
   { key: 'welding', label: 'Svařování', d:
@@ -7957,7 +7971,7 @@ function _symPickerBuild() {
     el.className = 'sym-picker-item' + (sym.key === _pendingSymbolKey ? ' active' : '');
     el.dataset.key = sym.key;
     el.title = sym.label;
-    el.innerHTML = `<svg viewBox="-12 -12 24 24" fill="currentColor" stroke="none"><path d="${sym.d}"/></svg><span>${sym.label}</span>`;
+    el.innerHTML = `<svg viewBox="-12 -12 24 24" fill="currentColor" stroke="none"><path d="${sym.d}" fill-rule="${sym.fillRule||'nonzero'}"/></svg><span>${sym.label}</span>`;
     el.addEventListener('click', e => { e.stopPropagation(); _symSelect(sym.key); });
     grid.appendChild(el);
   });
@@ -8034,6 +8048,7 @@ function placeSymbolAt(x, y) {
     fill: color,
     stroke: 'none',
     scaleX: 2, scaleY: 2,
+    fillRule: sym.fillRule || 'nonzero',
     selectable: true,
   });
   addAnnotationProperties(shape, 'symbol');


### PR DESCRIPTION
- Replace warning/generator/stairs/paint/survey with new icons: gloves, jackhammer, house, saw, hammer, tape (metr/pásmo)
- Update plumbing to cross-pipe, shovel to add collar, barrier to widen legs
- Add fillRule support: tape uses evenodd for donut reel hole
- _symPickerBuild: pass fill-rule attr on SVG path element
- placeSymbolAt: apply fillRule from symbol def to fabric.Path


Claude-Session: https://claude.ai/code/session_01Epw3iDtL3kUNnhbHKaqqCM