### PR TITLE
Zmenšit symboly stavebních činností na velikost špendlíku

### DIFF
--- a/index.html
+++ b/index.html
@@ -7941,7 +7941,8 @@ function placeSymbolAt(x, y) {
     originX: 'center', originY: 'center',
     fill: color,
     stroke: 'none',
-    scaleX: 2, scaleY: 2,
+    // viewBox 24x24 × 0.625 = 15 → stejná výška jako špendlík (placePinAt), žádný symbol ho nepřevyšuje.
+    scaleX: 0.625, scaleY: 0.625,
     fillRule: sym.fillRule || 'nonzero',
     selectable: true,
   });


### PR DESCRIPTION
Symboly byly vkládány s měřítkem 2x (48x48 jednotek), zatímco špendlík má výšku jen 15 jednotek. Sjednoceno na 0.625x, aby žádný symbol nebyl větší než špendlík.


Claude-Session: https://claude.ai/code/session_019otsBNi128Zax1rFWmUEDu