### PR TITLE
Docházkový list: rozdělit na víc stran, aby se nevynechávali dodavatelé

### DIFF
--- a/index.html
+++ b/index.html
@@ -10477,7 +10477,8 @@ function drawAnnotListToPDF(pdf, anns, lx, ly, lw, lh, targetCount) {
 
 // ── KD record pages (multi-page, fixed font size) ───────────────────────────
 // ============================================================
-// DOCHÁZKOVÝ LIST – jedna strana (A4 landscape) per KD záznam
+// DOCHÁZKOVÝ LIST – A4 landscape, rozdělí se na víc stran, pokud se
+// všichni dodavatelé nevejdou na jednu (stejný vzor jako drawKDRecordToPDF).
 // Interaktivní: datum a checkboxy jdou vyplnit v PDF readeru
 // ============================================================
 function drawDochazkaPDF(pdf, rec, pdfLogo, PW, PH) {
@@ -10491,68 +10492,14 @@ function drawDochazkaPDF(pdf, rec, pdfLogo, PW, PH) {
     return s + '…';
   };
 
-  // Only suppliers that have a firma filled in, sorted alphabetically
+  // Všichni dodavatelé, sorted alphabetically
   const suppliers = (appState.profese || [])
     .slice()
     .sort((a, b) => (a.firma || a.name).localeCompare(b.firma || b.name, 'cs'));
 
-  // ── Page header (shared with KD pages) ─────────────────────
-  pdf.setFillColor(255, 255, 255); pdf.rect(0, 0, PW, 11, 'F');
-  pdf.setDrawColor(210, 212, 208); pdf.setLineWidth(0.2); pdf.line(0, 11, PW, 11);
-  const _lH = 7.5, _lW = _lH * (943 / 840), _lX = 1.5, _lY = (11 - _lH) / 2;
-  if (pdfLogo) pdf.addImage(pdfLogo, 'PNG', _lX, _lY, _lW, _lH);
-  pdf.setFont('helvetica', 'bold'); pdf.setFontSize(9); pdf.setTextColor(60, 90, 25);
-  pdf.text('BeSix Plans', _lX + _lW + 1.5, 7.5);
-  pdf.setFont('helvetica', 'normal'); pdf.setTextColor(50, 55, 45);
-  pdf.text(cs(currentProject?.name || ''), 38, 7.5);
-
-  // ── Content box ────────────────────────────────────────────
   const lx = 4, ly = 13, lw = PW - 8, lh = PH - ly - 4;
-  pdf.setFillColor(255, 255, 255); pdf.rect(lx, ly, lw, lh, 'F');
-  pdf.setDrawColor(210, 212, 208); pdf.setLineWidth(0.15); pdf.rect(lx, ly, lw, lh, 'S');
-
-  // Title bar
-  const TITLE_H = 10;
-  pdf.setFillColor(242, 244, 240); pdf.rect(lx, ly, lw, TITLE_H, 'F');
-  pdf.setFont('helvetica', 'bold'); pdf.setFontSize(8); pdf.setTextColor(55, 80, 30);
-  pdf.text(cs('DOCHÁZKOVÝ LIST'), lx + 3, ly + TITLE_H * 0.65);
-
-  // "Datum konání KD:" label + editable text field
-  const dateLabel = 'Datum konani KD:';
-  pdf.setFont('helvetica', 'normal'); pdf.setFontSize(7); pdf.setTextColor(80, 85, 75);
-  const dateLabelW = pdf.getStringUnitWidth(dateLabel) * 7 / PT_MM;
-  const dateLabelX = lx + lw * 0.42;
-  const dateFieldX = dateLabelX + dateLabelW + 2;
-  const dateFieldW = 52;
-  pdf.text(dateLabel, dateLabelX, ly + TITLE_H * 0.65);
-
-  // Underline for the date field fallback
-  pdf.setDrawColor(140, 145, 130); pdf.setLineWidth(0.25);
-  pdf.line(dateFieldX, ly + TITLE_H * 0.70, dateFieldX + dateFieldW, ly + TITLE_H * 0.70);
-
-  // Interactive text field for date
-  try {
-    const tf = new pdf.AcroForm.TextField();
-    tf.fieldName = 'datum_kd_' + (rec.id || 'x');
-    tf.Rect = [dateFieldX, ly + 1.5, dateFieldW, TITLE_H - 3];
-    tf.value = rec.date ? rec.date.split('-').reverse().join('.') : '';
-    tf.fontSize = 7;
-    tf.borderColor = [180, 185, 170];
-    tf.borderWidth = 0.4;
-    pdf.addField(tf);
-  } catch(e) { /* fallback: underline already drawn */ }
-
-  // ── "Odeslat zápis" mailto button in title bar ────────────────
-  const allEmails = (appState.profese || []).flatMap(p => getProfEmails(p)).filter(Boolean);
-  if (allEmails.length) {
-    const btnLabel = cs('Odeslat zapis (' + allEmails.length + ')');
-    const btnW = pdf.getStringUnitWidth(btnLabel) * 6 / PT_MM + 6;
-    const btnX = lx + lw - btnW - 2, btnY = ly + (TITLE_H - 5.5) / 2;
-    pdf.setFillColor(60, 90, 25); pdf.roundedRect(btnX, btnY, btnW, 5.5, 0.8, 0.8, 'F');
-    pdf.setFont('helvetica', 'bold'); pdf.setFontSize(5.5); pdf.setTextColor(255, 255, 255);
-    pdf.text(btnLabel, btnX + 3, btnY + 5.5 * 0.72);
-    pdf.link(btnX, btnY, btnW, 5.5, { url: 'mailto:' + allEmails.join(';') });
-  }
+  const TITLE_H = 10, COLH_H = 6, FOOTER_H = 5;
+  const availForRows = lh - TITLE_H - COLH_H - FOOTER_H;
 
   // ── Column definitions ─────────────────────────────────────
   const COL_NR    = { x: lx + 1,   w: 8   };
@@ -10564,42 +10511,21 @@ function drawDochazkaPDF(pdf, rec, pdfLogo, PW, PH) {
   const COL_VCF   = { x: lx + 253, w: 12  };
   const COL_CHECK = { x: lx + 265, w: lw - 265 - 1 };
 
-  // ── Column header row ───────────────────────────────────────
-  const COLH_Y = ly + TITLE_H;
-  const COLH_H = 6;
-  pdf.setFillColor(228, 232, 220); pdf.rect(lx, COLH_Y, lw, COLH_H, 'F');
-  pdf.setFont('helvetica', 'bold'); pdf.setFontSize(5.5); pdf.setTextColor(55, 70, 30);
-  const colHdrY = COLH_Y + COLH_H * 0.68;
-  pdf.text('#',                   COL_NR.x,    colHdrY);
-  pdf.text('Firma / Dodavatel',   COL_FIRMA.x, colHdrY);
-  pdf.text('Profese / Role',      COL_ROLE.x,  colHdrY);
-  pdf.text('Kontaktni osoba',     COL_KONT.x,  colHdrY);
-  pdf.text('Telefon',             COL_TEL.x,   colHdrY);
-  pdf.text('E-mail',              COL_EMAIL.x, colHdrY);
-  pdf.text('Vizitka',             COL_VCF.x + 0.5, colHdrY);
-  pdf.text('Pritomen',            COL_CHECK.x, colHdrY);
-
-  // Vertical header separators
-  pdf.setDrawColor(200, 205, 190); pdf.setLineWidth(0.12);
-  [COL_FIRMA, COL_ROLE, COL_KONT, COL_TEL, COL_EMAIL, COL_VCF, COL_CHECK].forEach(c => {
-    pdf.line(c.x - 1, COLH_Y, c.x - 1, COLH_Y + COLH_H);
-  });
-
-  // ── Data rows — height scales so all suppliers fit on one page ─
-  const minRows      = 8;
-  const rowCount     = Math.max(suppliers.length, minRows);
-  const availForRows = lh - TITLE_H - COLH_H - 5; // 5mm footer reserve
-  const BASE_ROW_H  = Math.min(9, Math.max(4, Math.floor(availForRows / rowCount)));
+  // ── Řádkové rozměry — dorovnají se, aby se malý počet dodavatelů hezky
+  // vešel na jednu stránku, ale nikdy neklesnou pod čitelných 6mm (dřív šlo
+  // až na 4mm a přebývající dodavatelé se pak potichu nevykreslili) ────────
+  const minRows = 8;
+  const MIN_ROW_H = 6, MAX_ROW_H = 9;
+  const BASE_ROW_H = Math.min(MAX_ROW_H, Math.max(MIN_ROW_H, Math.floor(availForRows / Math.max(suppliers.length, minRows))));
   const ROW_FS = Math.max(4, BASE_ROW_H * 0.67);
-  const LINE_H = ROW_FS / (72 / 25.4) * 1.4; // line height in mm
-  let curY = COLH_Y + COLH_H;
+  const LINE_H = ROW_FS / PT_MM * 1.4; // line height in mm
 
-  suppliers.forEach((p, i) => {
+  // ── Předpočítat zalomení e-mailů/kontaktů a výšku řádku pro každého dodavatele ─
+  const twFn = s => pdf.getStringUnitWidth(s) * ROW_FS / PT_MM;
+  const SEP = '  '; const sepW = twFn(SEP);
+  const rows = suppliers.map(p => {
     const pEmails = getProfEmails(p);
-
     // Pack emails side-by-side; wrap to next line only when column is full
-    const twFn = s => pdf.getStringUnitWidth(s) * ROW_FS / PT_MM;
-    const SEP = '  ';  const sepW = twFn(SEP);
     const emailWrapped = []; // [{email, txt, xOff}] per line
     if (pEmails.length) {
       let curLine = [], lineW = 0;
@@ -10617,14 +10543,109 @@ function drawDochazkaPDF(pdf, rec, pdfLogo, PW, PH) {
       });
       if (curLine.length) emailWrapped.push(curLine);
     }
-
-    const numELines   = Math.max(1, emailWrapped.length);
-    const _ctacts     = getAllContacts(p);
-    const numCLines   = Math.max(1, _ctacts.length);
-    const numRowLines = Math.max(numELines, numCLines);
+    const ctacts = getAllContacts(p);
+    const numRowLines = Math.max(1, emailWrapped.length, ctacts.length);
     const ROW_H = numRowLines > 1 ? Math.max(BASE_ROW_H, LINE_H * numRowLines + 2) : BASE_ROW_H;
+    return { p, emailWrapped, ctacts, ROW_H };
+  });
+
+  // ── Hlavička stránky (top bar, rámeček, titulek, hlavička sloupců) ──────
+  // Na první straně navíc datum KD a mailto tlačítko; na dalších stranách
+  // jen štítek "pokračování" — stejný vzor jako drawKDRecordToPDF.
+  const drawHeader = isFirstPage => {
+    pdf.setFillColor(255, 255, 255); pdf.rect(0, 0, PW, 11, 'F');
+    pdf.setDrawColor(210, 212, 208); pdf.setLineWidth(0.2); pdf.line(0, 11, PW, 11);
+    const _lH = 7.5, _lW = _lH * (943 / 840), _lX = 1.5, _lY = (11 - _lH) / 2;
+    if (pdfLogo) pdf.addImage(pdfLogo, 'PNG', _lX, _lY, _lW, _lH);
+    pdf.setFont('helvetica', 'bold'); pdf.setFontSize(9); pdf.setTextColor(60, 90, 25);
+    pdf.text('BeSix Plans', _lX + _lW + 1.5, 7.5);
+    pdf.setFont('helvetica', 'normal'); pdf.setTextColor(50, 55, 45);
+    pdf.text(cs(currentProject?.name || ''), 38, 7.5);
+
+    pdf.setFillColor(255, 255, 255); pdf.rect(lx, ly, lw, lh, 'F');
+    pdf.setDrawColor(210, 212, 208); pdf.setLineWidth(0.15); pdf.rect(lx, ly, lw, lh, 'S');
+
+    pdf.setFillColor(242, 244, 240); pdf.rect(lx, ly, lw, TITLE_H, 'F');
+    pdf.setFont('helvetica', 'bold'); pdf.setFontSize(8); pdf.setTextColor(55, 80, 30);
+    pdf.text(cs('DOCHÁZKOVÝ LIST'), lx + 3, ly + TITLE_H * 0.65);
+
+    if (isFirstPage) {
+      // "Datum konání KD:" label + editable text field
+      const dateLabel = 'Datum konani KD:';
+      pdf.setFont('helvetica', 'normal'); pdf.setFontSize(7); pdf.setTextColor(80, 85, 75);
+      const dateLabelW = pdf.getStringUnitWidth(dateLabel) * 7 / PT_MM;
+      const dateLabelX = lx + lw * 0.42;
+      const dateFieldX = dateLabelX + dateLabelW + 2;
+      const dateFieldW = 52;
+      pdf.text(dateLabel, dateLabelX, ly + TITLE_H * 0.65);
+
+      // Underline for the date field fallback
+      pdf.setDrawColor(140, 145, 130); pdf.setLineWidth(0.25);
+      pdf.line(dateFieldX, ly + TITLE_H * 0.70, dateFieldX + dateFieldW, ly + TITLE_H * 0.70);
+
+      // Interactive text field for date
+      try {
+        const tf = new pdf.AcroForm.TextField();
+        tf.fieldName = 'datum_kd_' + (rec.id || 'x');
+        tf.Rect = [dateFieldX, ly + 1.5, dateFieldW, TITLE_H - 3];
+        tf.value = rec.date ? rec.date.split('-').reverse().join('.') : '';
+        tf.fontSize = 7;
+        tf.borderColor = [180, 185, 170];
+        tf.borderWidth = 0.4;
+        pdf.addField(tf);
+      } catch(e) { /* fallback: underline already drawn */ }
+
+      // "Odeslat zápis" mailto button in title bar
+      const allEmails = (appState.profese || []).flatMap(p => getProfEmails(p)).filter(Boolean);
+      if (allEmails.length) {
+        const btnLabel = cs('Odeslat zapis (' + allEmails.length + ')');
+        const btnW = pdf.getStringUnitWidth(btnLabel) * 6 / PT_MM + 6;
+        const btnX = lx + lw - btnW - 2, btnY = ly + (TITLE_H - 5.5) / 2;
+        pdf.setFillColor(60, 90, 25); pdf.roundedRect(btnX, btnY, btnW, 5.5, 0.8, 0.8, 'F');
+        pdf.setFont('helvetica', 'bold'); pdf.setFontSize(5.5); pdf.setTextColor(255, 255, 255);
+        pdf.text(btnLabel, btnX + 3, btnY + 5.5 * 0.72);
+        pdf.link(btnX, btnY, btnW, 5.5, { url: 'mailto:' + allEmails.join(';') });
+      }
+    } else {
+      pdf.setFont('helvetica', 'normal'); pdf.setFontSize(6); pdf.setTextColor(120, 125, 115);
+      pdf.text(cs('pokracovani...'), lx + lw * 0.42, ly + TITLE_H * 0.65);
+    }
+
+    // Column header row
+    const COLH_Y = ly + TITLE_H;
+    pdf.setFillColor(228, 232, 220); pdf.rect(lx, COLH_Y, lw, COLH_H, 'F');
+    pdf.setFont('helvetica', 'bold'); pdf.setFontSize(5.5); pdf.setTextColor(55, 70, 30);
+    const colHdrY = COLH_Y + COLH_H * 0.68;
+    pdf.text('#',                   COL_NR.x,    colHdrY);
+    pdf.text('Firma / Dodavatel',   COL_FIRMA.x, colHdrY);
+    pdf.text('Profese / Role',      COL_ROLE.x,  colHdrY);
+    pdf.text('Kontaktni osoba',     COL_KONT.x,  colHdrY);
+    pdf.text('Telefon',             COL_TEL.x,   colHdrY);
+    pdf.text('E-mail',              COL_EMAIL.x, colHdrY);
+    pdf.text('Vizitka',             COL_VCF.x + 0.5, colHdrY);
+    pdf.text('Pritomen',            COL_CHECK.x, colHdrY);
+
+    pdf.setDrawColor(200, 205, 190); pdf.setLineWidth(0.12);
+    [COL_FIRMA, COL_ROLE, COL_KONT, COL_TEL, COL_EMAIL, COL_VCF, COL_CHECK].forEach(c => {
+      pdf.line(c.x - 1, COLH_Y, c.x - 1, COLH_Y + COLH_H);
+    });
+
+    // Footer note
+    pdf.setFont('helvetica', 'italic'); pdf.setFontSize(4.5); pdf.setTextColor(150, 155, 140);
+    pdf.text('* Datum konani KD a pritomnost ucastniku lze upravit primo v PDF readeru.', lx + 2, ly + lh - 1.5);
+
+    return COLH_Y + COLH_H;
+  };
+
+  const pageBottom = ly + lh - FOOTER_H;
+  let curY = drawHeader(true);
+
+  rows.forEach(({ p, emailWrapped, ctacts, ROW_H }, i) => {
+    if (curY + ROW_H > pageBottom) {
+      pdf.addPage();
+      curY = drawHeader(false);
+    }
     const rowY = curY;
-    if (rowY + ROW_H > ly + lh) return; // overflow guard
 
     // Supplier color
     const [r, g, b] = hexToRgb(p.color || '#888888');
@@ -10653,12 +10674,12 @@ function drawDochazkaPDF(pdf, rec, pdfLogo, PW, PH) {
     pdf.text(fitT(p.name, ROW_FS, COL_ROLE.w - 2), COL_ROLE.x, midY);
     pdf.setTextColor(40, 45, 35);
     // Kontaktní osoby — stacked per contact
-    if (_ctacts.length <= 1) {
-      const _c = _ctacts[0] || {};
+    if (ctacts.length <= 1) {
+      const _c = ctacts[0] || {};
       pdf.text(fitT(_c.name    || '', ROW_FS, COL_KONT.w - 2), COL_KONT.x, midY);
       pdf.text(fitT(_c.telefon || '', ROW_FS, COL_TEL.w - 2),  COL_TEL.x,  midY);
     } else {
-      _ctacts.forEach((_c, _ci) => {
+      ctacts.forEach((_c, _ci) => {
         const _cY = rowY + LINE_H * (_ci + 0.85);
         pdf.text(fitT(_c.name    || '', ROW_FS, COL_KONT.w - 2), COL_KONT.x, _cY);
         pdf.text(fitT(_c.telefon || '', ROW_FS, COL_TEL.w - 2),  COL_TEL.x,  _cY);
@@ -10720,8 +10741,8 @@ function drawDochazkaPDF(pdf, rec, pdfLogo, PW, PH) {
     curY += ROW_H;
   });
 
-  // Empty rows if fewer than minRows suppliers
-  for (let i = suppliers.length; i < minRows && curY + BASE_ROW_H <= ly + lh; i++) {
+  // Empty rows if fewer than minRows suppliers (only on the last/only page)
+  for (let i = rows.length; i < minRows && curY + BASE_ROW_H <= pageBottom; i++) {
     const rowY = curY;
     if (i % 2 === 0) { pdf.setFillColor(249, 251, 246); pdf.rect(lx, rowY, lw, BASE_ROW_H, 'F'); }
     const tY = rowY + BASE_ROW_H * 0.62;
@@ -10748,10 +10769,6 @@ function drawDochazkaPDF(pdf, rec, pdfLogo, PW, PH) {
     });
     curY += BASE_ROW_H;
   }
-
-  // Footer note
-  pdf.setFont('helvetica', 'italic'); pdf.setFontSize(4.5); pdf.setTextColor(150, 155, 140);
-  pdf.text('* Datum konani KD a pritomnost ucastniku lze upravit primo v PDF readeru.', lx + 2, ly + lh - 1.5);
 }
 
 function drawKDRecordToPDF(pdf, rec, pdfLogo, PW, PH, inclDone, kdSubFilter = [], pinnedProfNames = []) {


### PR DESCRIPTION
Docházkový list se dosud vykresloval vždy jen na jednu stranu a výška řádku se zmenšovala až na 4mm, aby se všichni vešli. Když se ani tak nevešli, přebývající dodavatelé (v abecedním pořadí) se potichu nevykreslili — bez varování a bez pokračování na další straně.

Teď se minimální výška řádku drží na čitelných 6mm a pokud se dodavatelé nevejdou na jednu stránku, docházkový list pokračuje na další straně (stejně jako to už dřív dělal export záznamů z kontrolního dne).