### PR TITLE
Nespouštět ALTER TABLE remember_tokens na každý request

### DIFF
--- a/api/functions.php
+++ b/api/functions.php
@@ -64,8 +64,21 @@ function _ensureRememberTable(): void {
         INDEX idx_uid (user_id),
         INDEX idx_exp (expires_at)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4");
-    // Table may already exist from before idx_exp was added — add it if missing.
-    try { $db->exec('ALTER TABLE remember_tokens ADD INDEX idx_exp (expires_at)'); } catch (\PDOException $e) {}
+    // Tabulka mohla existovat už předtím, než byl přidán idx_exp. Nejdřív ověřit přes
+    // information_schema (levný SELECT, žádný metadata lock) a ALTER TABLE spustit
+    // jen když index opravdu chybí — jinak by se kvůli tomuto self-healing kroku
+    // zbytečně zatěžovala DB při každém requestu (remember-me se ověřuje i při pollingu).
+    $hasIdx = (int) $db->query(
+        "SELECT COUNT(*) FROM information_schema.STATISTICS
+         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'remember_tokens' AND INDEX_NAME = 'idx_exp'"
+    )->fetchColumn();
+    if (!$hasIdx) {
+        try {
+            $db->exec('ALTER TABLE remember_tokens ADD INDEX idx_exp (expires_at)');
+        } catch (\PDOException $e) {
+            error_log('[remember_tokens] add idx_exp failed: ' . $e->getMessage());
+        }
+    }
     $done = true;
 }
 


### PR DESCRIPTION
_ensureRememberTable() se volá při ověření remember-me cookie prakticky při každém requestu (login i pravidelný polling ~2s). Dřív se na každý z nich zkusil ALTER TABLE ADD INDEX (obalený v try/catch na duplicate key) i když index už dávno existoval — zbytečná zátěž DB a riziko metadata-lock kontence při souběžných requestech.

Teď se existence idx_exp nejdřív ověří levým SELECTem z information_schema.STATISTICS a ALTER TABLE se spustí jen když index opravdu chybí. Catch blok navíc loguje neočekávané chyby místo tichého spolknutí.