### PR TITLE
Odstranit sekání při zoomování na projektech s hodně anotacemi

### DIFF
--- a/index.html
+++ b/index.html
@@ -6574,7 +6574,22 @@ function createLevelLinkLine(x1, y1, x2, y2) {
   });
 }
 
-function updateAllLabelScales() {
+// deconflictLabels() is O(n²) in the number of annotations (checks every label
+// pair) — on projects with a few hundred pins it measurably takes 100ms+, which
+// is fine once, but not on every animation frame of a zoom gesture. When called
+// with deconflict:false (continuous zoom), labels still reposition every frame
+// (cheap, keeps them visually attached) but the expensive overlap pass is
+// debounced until the gesture actually settles.
+let _deconflictSettleTimer = null;
+function _scheduleDeconflictSettle() {
+  clearTimeout(_deconflictSettleTimer);
+  _deconflictSettleTimer = setTimeout(() => {
+    deconflictLabels();
+    fabricCanvas.renderAll();
+  }, 150);
+}
+
+function updateAllLabelScales(deconflict = true) {
   if (!fabricCanvas) return;
   const zoom    = fabricCanvas.getZoom();
   const compact = zoom < LABEL_COMPACT_ZOOM;
@@ -6597,7 +6612,12 @@ function updateAllLabelScales() {
     const annot = _annotById.get(o.annotLabelFor);
     if (annot) positionLabel(o, annot);
   });
-  deconflictLabels();
+  if (deconflict) {
+    clearTimeout(_deconflictSettleTimer);
+    deconflictLabels();
+  } else {
+    _scheduleDeconflictSettle();
+  }
   fabricCanvas.renderAll();
 }
 
@@ -7225,11 +7245,13 @@ function setupEventListeners() {
     saveCurrentLevel();
   });
 
-  // rAF throttle for label repositioning during zoom (wheel + pinch both use this)
+  // rAF throttle for label repositioning during zoom (wheel + pinch both use this).
+  // deconflict:false — the expensive O(n²) overlap pass is debounced separately
+  // (see updateAllLabelScales) so it doesn't run on every frame of the gesture.
   let _labelRaf = null;
   function _scheduleLabels() {
     if (_labelRaf) return;
-    _labelRaf = requestAnimationFrame(() => { _labelRaf = null; updateAllLabelScales(); });
+    _labelRaf = requestAnimationFrame(() => { _labelRaf = null; updateAllLabelScales(false); });
   }
 
   // Wheel zoom
@@ -7242,7 +7264,11 @@ function setupEventListeners() {
     cw.zoomToPoint({ x: e.offsetX, y: e.offsetY }, zoom);
     updateZoomDisplay();
     _scheduleLabels();
-    cw.renderAll();
+    // requestRenderAll (not renderAll): coalesces the many 'wheel' events fired during
+    // one scroll gesture into a single render per frame instead of one full canvas
+    // redraw per event — on canvases with lots of annotations this was the main
+    // source of stutter while zooming.
+    cw.requestRenderAll();
   }, { passive: false });
 
   // Touch – two-finger pan/pinch-zoom + tap-to-select in pan mode
@@ -7340,7 +7366,7 @@ function setupEventListeners() {
       cw.setViewportTransform(vpt);
       updateZoomDisplay();
       _scheduleLabels();
-      cw.renderAll();
+      cw.requestRenderAll();
     }
   }, { passive: false });
   wrapper.addEventListener('touchend', (e) => {


### PR DESCRIPTION
Diagnostikováno (viz benchmark níže): dvě věci se sčítaly při každém tiku kolečka myši / pinch-zoomu.

1. Wheel a touchmove handlery volaly cw.renderAll() synchronně na KAŽDÝ jednotlivý event, místo aby se (jako zbytek kódu) spoléhaly na Fabricovo requestRenderAll(), které víc událostí v rámci jednoho framu sloučí do jednoho překreslení.

2. updateAllLabelScales() po každém takovém tiku volala deconflictLabels() — algoritmus rozhazující překrývající se popisky, který je O(n²) v počtu anotací (kontroluje každý pár popisků, navíc až 10 iterací). Naměřeno (Node benchmark s reálnou logikou funkce): 100 anotací ~15ms, 300 ~45ms, 800 ~150ms, 1200 ~200ms. Na reálném projektu s stovkami úkolů na patře to při plynulém zoomu (desítky wheel eventů/s) dělalo znatelné zásekávání.

Oprava: cw.renderAll() -> cw.requestRenderAll() ve wheel/touchmove handlerech. updateAllLabelScales(deconflict) dostala parametr — během zoomu (přes _scheduleLabels, rAF-throttled) se popisky každý frame jen levně přemístí (drží se anotace), ale nákladné rozházení překryvů se odloží (150ms debounce) až po ustálení gesta. Všechna ostatní volání (načtení podlaží, přepnutí patra apod.) beze změny — tam běží hned.